### PR TITLE
Allow customers to cancel pending orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This template comes configured with the bare minimum to get started on anything 
 - **Place Orders**: Add snacks to cart and place orders
 - **Order History**: View personal order history with status tracking
 - **Order Tracking**: See order status (Pending, Completed, Cancelled)
+- **Cancel Pending Orders**: Cancel orders while they are still pending
 
 ### 🔧 Admin Features
 - **Enhanced Admin Dashboard**: Comprehensive order management with analytics
@@ -37,7 +38,8 @@ This template comes configured with the bare minimum to get started on anything 
 - Can view all available snacks
 - Can place orders for snacks
 - Can view their own order history
-- Cannot modify or cancel orders once placed
+- Cannot modify orders once placed
+- Can cancel orders while status is pending
 
 ### Admin Users (`role: 'admin'`)
 - All regular user permissions
@@ -120,6 +122,7 @@ This template comes configured with the bare minimum to get started on anything 
 ### Orders
 - `POST /api/orders` - Create a new order (authenticated users)
 - `PATCH /api/orders/update-status` - Update order status (admin only)
+- `POST /api/orders/cancel` - Cancel a pending order (authenticated users)
 
 ### Built-in Payload Endpoints
 - `/api/users` - User management

--- a/src/app/(frontend)/my-orders/CancelOrderButton.tsx
+++ b/src/app/(frontend)/my-orders/CancelOrderButton.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState, startTransition } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+export function CancelOrderButton({ orderId }: { orderId: string | number }) {
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+
+  const handleCancel = async () => {
+    setLoading(true)
+    try {
+      await fetch('/api/orders/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orderId }),
+      })
+      startTransition(() => {
+        router.refresh()
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Button variant="destructive" onClick={handleCancel} disabled={loading}>
+      Cancel Order
+    </Button>
+  )
+}
+

--- a/src/app/(frontend)/my-orders/page.tsx
+++ b/src/app/(frontend)/my-orders/page.tsx
@@ -12,6 +12,7 @@ import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Separator } from '@/components/ui/separator'
 import { SiteHeader } from '@/components/site-header'
+import { CancelOrderButton } from './CancelOrderButton'
 
 export default async function MyOrdersPage({
   searchParams,
@@ -173,6 +174,11 @@ export default async function MyOrdersPage({
                       Total: ৳{order.totalAmount.toFixed(2)}
                     </span>
                   </div>
+                  {order.status === 'pending' && (
+                    <div className="text-right mt-4">
+                      <CancelOrderButton orderId={order.id} />
+                    </div>
+                  )}
                 </CardContent>
               </Card>
             ))}

--- a/src/app/api/orders/cancel/route.ts
+++ b/src/app/api/orders/cancel/route.ts
@@ -1,0 +1,60 @@
+import { headers as getHeaders } from 'next/headers.js'
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+
+import config from '@/payload.config'
+
+export async function POST(request: NextRequest) {
+  try {
+    const headers = await getHeaders()
+    const payloadConfig = await config
+    const payload = await getPayload({ config: payloadConfig })
+    const { user } = await payload.auth({ headers })
+
+    if (!user) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+
+    let body: any = {}
+    try {
+      body = await request.json()
+    } catch {}
+    const { orderId } = body
+
+    if (!orderId) {
+      return NextResponse.json({ message: 'Order ID is required' }, { status: 400 })
+    }
+
+    const order = await payload.findByID({
+      collection: 'orders',
+      id: orderId,
+      depth: 0,
+    })
+
+    if (!order) {
+      return NextResponse.json({ message: 'Order not found' }, { status: 404 })
+    }
+
+    if (String((order as any).user) !== String((user as any).id)) {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 })
+    }
+
+    if ((order as any).status !== 'pending') {
+      return NextResponse.json({ message: 'Only pending orders can be cancelled' }, { status: 400 })
+    }
+
+    const updatedOrder = await payload.update({
+      collection: 'orders',
+      id: orderId,
+      data: { status: 'cancelled' },
+      overrideAccess: true,
+      user,
+    })
+
+    return NextResponse.json({ success: true, order: updatedOrder }, { status: 200 })
+  } catch (error) {
+    console.error('Order cancel error:', error)
+    return NextResponse.json({ message: 'Internal server error' }, { status: 500 })
+  }
+}
+


### PR DESCRIPTION
## Summary
- add API route letting a user cancel their own pending order
- expose Cancel Order button on My Orders page
- document cancelling pending orders in README

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c623f493c0832ab3df0adc3bf9baf7