### PR TITLE
fix: responsive add-to-cart button

### DIFF
--- a/src/components/add-to-cart-button.tsx
+++ b/src/components/add-to-cart-button.tsx
@@ -53,17 +53,22 @@ export const AddToCartButton: React.FC<AddToCartButtonProps> = ({ item }) => {
       onClick={handleAddToCart}
       disabled={isAdded}
       size="sm"
-      className={`px-2 sm:px-4 py-2 text-xs sm:text-sm ${isAdded ? 'bg-green-600 hover:bg-green-600' : ''}`}
+      className={`
+        h-8 px-2 text-xs
+        sm:h-9 sm:px-4 sm:text-sm
+        md:h-10 md:px-6 md:text-base
+        ${isAdded ? 'bg-green-600 hover:bg-green-600' : ''}
+      `}
     >
       {isAdded ? (
         <>
-          <Check className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
+          <Check className="h-3 w-3 sm:h-4 sm:w-4 md:h-5 md:w-5 mr-1 sm:mr-2 md:mr-3" />
           <span className="hidden sm:inline">Added!</span>
           <span className="sm:hidden">✓</span>
         </>
       ) : (
         <>
-          <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
+          <Plus className="h-3 w-3 sm:h-4 sm:w-4 md:h-5 md:w-5 mr-1 sm:mr-2 md:mr-3" />
           <span className="hidden sm:inline">Add to Cart</span>
           <span className="sm:hidden">Add</span>
         </>


### PR DESCRIPTION
## Summary
- adjust add-to-cart button dimensions and icon sizes based on screen width

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68c62a365924832a89d18920ab53cba4