### PR TITLE
chore: lazy load heavy client components

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,11 +1,23 @@
 import React from 'react'
+import dynamic from 'next/dynamic'
+
 import { CartProvider } from '@/lib/cart-context'
-import { CartSidebar } from '@/components/cart-sidebar'
 import { SiteFooter } from '@/components/site-footer'
 import '../globals.css'
 import { Toaster } from '@/components/ui/sonner'
-import { Analytics } from '@vercel/analytics/next'
-import { SpeedInsights } from '@vercel/speed-insights/next'
+
+// Lazily load heavier client components to reduce initial bundle size
+const CartSidebar = dynamic(() => import('@/components/cart-sidebar'), {
+  ssr: false,
+})
+const Analytics = dynamic(
+  () => import('@vercel/analytics/next').then((mod) => mod.Analytics),
+  { ssr: false },
+)
+const SpeedInsights = dynamic(
+  () => import('@vercel/speed-insights/next').then((mod) => mod.SpeedInsights),
+  { ssr: false },
+)
 
 export const metadata = {
   description: 'Online Bazar — a mini store template powered by Payload.',


### PR DESCRIPTION
## Summary
- lazy load cart sidebar and analytics scripts to reduce initial bundle size

## Testing
- `pnpm lint`
- `pnpm build` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_68c633e4d398832aaf03b1cfad0d77dd