### PR TITLE
fix: remove extra main tags and adjust aria-hidden usage

### DIFF
--- a/src/app/(frontend)/item/[id]/page.tsx
+++ b/src/app/(frontend)/item/[id]/page.tsx
@@ -82,7 +82,7 @@ export default async function ItemPage({ params }: { params: Promise<{ id: strin
   return (
     <div className="min-h-screen bg-gray-50">
       <SiteHeader variant="full" user={user} />
-      <main className="container mx-auto px-4 py-8">
+      <div className="container mx-auto px-4 py-8">
         <div className="grid md:grid-cols-2 gap-8 lg:gap-12">
           <div>
             {((item.image && typeof item.image === 'object') || item.imageUrl) && (
@@ -172,7 +172,7 @@ export default async function ItemPage({ params }: { params: Promise<{ id: strin
             </TabsContent>
           </Tabs>
         </div>
-      </main>
+      </div>
     </div>
   )
 }

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -61,7 +61,7 @@ export default async function HomePage() {
 
       <SiteHeader variant="full" user={user} />
 
-      <main className="relative z-10">
+      <div className="relative z-10">
         {/* Hero Section */}
         <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
           {/* Floating Elements */}
@@ -201,7 +201,7 @@ export default async function HomePage() {
             )}
           </section>
         </div>
-      </main>
+      </div>
 
       {/* Global footer is rendered via layout */}
     </div>

--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -24,7 +24,7 @@ export default async function PrivacyPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       <SiteHeader variant="full" user={user} />
-      <main className="container mx-auto px-4 py-12 prose prose-gray max-w-3xl">
+      <div className="container mx-auto px-4 py-12 prose prose-gray max-w-3xl">
         <h1 className="brand-text text-4xl font-extrabold">Privacy Policy</h1>
         <p className="text-sm text-gray-500">Last updated: {updated}</p>
 
@@ -81,7 +81,7 @@ export default async function PrivacyPage() {
           Phone: <a href="tel:01739416661">01739-416661</a><br />
           Facebook: <a href="https://www.facebook.com/onlinebazarbarguna" target="_blank" rel="noreferrer">@onlinebazarbarguna</a>
         </p>
-      </main>
+      </div>
     </div>
   )
 }

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -20,10 +20,10 @@ export default async function ProfilePage() {
   return (
     <div className="min-h-screen bg-gray-50">
       <SiteHeader variant="full" user={user} />
-      <main className="container mx-auto px-4 py-8 max-w-3xl">
+      <div className="container mx-auto px-4 py-8 max-w-3xl">
         <h1 className="text-3xl font-bold mb-6">My Profile</h1>
         <ProfileForm user={user} />
-      </main>
+      </div>
     </div>
   )
 }

--- a/src/app/(frontend)/snack/[id]/page.tsx
+++ b/src/app/(frontend)/snack/[id]/page.tsx
@@ -36,7 +36,7 @@ export default async function SnackPage({ params }: { params: Promise<{ id: stri
   return (
     <div className="min-h-screen bg-gray-50">
       <SiteHeader variant="full" user={user} />
-      <main className="container mx-auto px-4 py-8">
+      <div className="container mx-auto px-4 py-8">
         <div className="grid md:grid-cols-2 gap-8 lg:gap-12">
           <div>
             {((snack.image && typeof snack.image === 'object') || snack.imageUrl) && (
@@ -80,7 +80,7 @@ export default async function SnackPage({ params }: { params: Promise<{ id: stri
             </div>
           </div>
         </div>
-      </main>
+      </div>
     </div>
   )
 }

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -87,12 +87,10 @@ function BreadcrumbEllipsis({
   return (
     <span
       data-slot="breadcrumb-ellipsis"
-      role="presentation"
-      aria-hidden="true"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontal className="size-4" />
+      <MoreHorizontal className="size-4" aria-hidden="true" />
       <span className="sr-only">More</span>
     </span>
   )

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -105,12 +105,11 @@ function PaginationEllipsis({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      aria-hidden
       data-slot="pagination-ellipsis"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontalIcon className="size-4" />
+      <MoreHorizontalIcon className="size-4" aria-hidden="true" />
       <span className="sr-only">More pages</span>
     </span>
   )


### PR DESCRIPTION
## Summary
- ensure decorative icons use `aria-hidden` without hiding their accessible labels
- rely on layout's `<main>` by removing redundant `main` elements from frontend pages

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c668677600832ab034e08c3dcdd8ee