### PR TITLE
Use Next.js Link for internal navigation

### DIFF
--- a/src/components/before-dashboard/seed-button.tsx
+++ b/src/components/before-dashboard/seed-button.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { Fragment, useCallback, useState } from 'react'
+import Link from 'next/link'
 import { toast } from '@payloadcms/ui'
 
 import './index.scss'
@@ -8,9 +9,9 @@ import './index.scss'
 const SuccessMessage: React.FC = () => (
   <div>
     Database seeded! You can now{' '}
-    <a target="_blank" href="/">
+    <Link href="/" target="_blank" rel="noreferrer">
       visit your website
-    </a>
+    </Link>
   </div>
 )
 


### PR DESCRIPTION
## Summary
- Replace internal `<a>` tag in the seed button success message with Next.js `<Link>` to ensure consistent in-app navigation

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68c66bacaebc832abce9ca2344e0e06f