### PR TITLE
feat: dynamically load non-critical components

### DIFF
--- a/src/app/(frontend)/admin-dashboard/page.tsx
+++ b/src/app/(frontend)/admin-dashboard/page.tsx
@@ -6,12 +6,17 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import config from '@/payload.config'
-import OrderStatusUpdate from './order-status-update'
+import dynamic from 'next/dynamic'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { SiteHeader } from '@/components/site-header'
+
+const OrderStatusUpdate = dynamic(() => import('./order-status-update'), {
+  loading: () => <div className="text-xs text-gray-500">Loading...</div>,
+  ssr: false,
+})
 
 export default async function AdminDashboardPage() {
   const headers = await getHeaders()

--- a/src/app/(frontend)/admin-dashboard/page.tsx
+++ b/src/app/(frontend)/admin-dashboard/page.tsx
@@ -6,17 +6,12 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import config from '@/payload.config'
-import dynamic from 'next/dynamic'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { SiteHeader } from '@/components/site-header'
-
-const OrderStatusUpdate = dynamic(() => import('./order-status-update'), {
-  loading: () => <div className="text-xs text-gray-500">Loading...</div>,
-  ssr: false,
-})
+import { OrderStatusUpdate } from '@/components/lazy-client-components'
 
 export default async function AdminDashboardPage() {
   const headers = await getHeaders()

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 import { CartProvider } from '@/lib/cart-context'
 import { SiteFooter } from '@/components/site-footer'
 import '../globals.css'
-import { Toaster } from '@/components/ui/sonner'
 import {
   CartSidebar,
   Analytics,
   SpeedInsights,
+  Toaster,
 } from '@/components/lazy-client-components'
 
 export const metadata = {

--- a/src/components/lazy-client-components.tsx
+++ b/src/components/lazy-client-components.tsx
@@ -18,3 +18,10 @@ export const Toaster = dynamic(
   () => import('@/components/ui/sonner').then((mod) => mod.Toaster),
   { ssr: false },
 )
+export const OrderStatusUpdate = dynamic(
+  () => import('@/app/(frontend)/admin-dashboard/order-status-update'),
+  {
+    loading: () => <div className="text-xs text-gray-500">Loading...</div>,
+    ssr: false,
+  },
+)

--- a/src/components/lazy-client-components.tsx
+++ b/src/components/lazy-client-components.tsx
@@ -14,3 +14,7 @@ export const SpeedInsights = dynamic(
   () => import('@vercel/speed-insights/next').then((mod) => mod.SpeedInsights),
   { ssr: false },
 )
+export const Toaster = dynamic(
+  () => import('@/components/ui/sonner').then((mod) => mod.Toaster),
+  { ssr: false },
+)


### PR DESCRIPTION
## Summary
- lazy load cart toaster and analytics helpers
- dynamically import admin order status update widget

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c66c2c7ce0832aaa726f5557a473da