### PR TITLE
Fix hydration mismatch from locale-specific rendering

### DIFF
--- a/src/app/(frontend)/admin-dashboard/page.tsx
+++ b/src/app/(frontend)/admin-dashboard/page.tsx
@@ -375,6 +375,7 @@ export default async function AdminDashboardPage() {
                             day: 'numeric',
                             hour: '2-digit',
                             minute: '2-digit',
+                            timeZone: 'UTC',
                           })}
                         </p>
                       </div>
@@ -561,7 +562,7 @@ export default async function AdminDashboardPage() {
                         </CardTitle>
                         <CardDescription className="mt-1 flex items-center gap-4">
                           <span className="flex items-center gap-1">
-                            🕰️ Last activity: {new Date(cart.lastActivityAt).toLocaleString()}
+                            🕰️ Last activity: {new Date(cart.lastActivityAt).toLocaleString('en-US', { timeZone: 'UTC' })}
                           </span>
                           {cart.status === 'abandoned' && (
                             <span className="text-red-600 font-medium">⚠️ Needs Recovery</span>

--- a/src/app/(frontend)/item/[id]/ReviewSection.tsx
+++ b/src/app/(frontend)/item/[id]/ReviewSection.tsx
@@ -87,7 +87,7 @@ export default function ReviewSection({
               <li key={r.id} className="border rounded-lg p-4 bg-white">
                 <div className="flex items-center justify-between">
                   <ReviewStars value={r.rating} />
-                  <span className="text-xs text-gray-500">{r.createdAt ? new Date(r.createdAt).toLocaleDateString() : ''}</span>
+                  <span className="text-xs text-gray-500">{r.createdAt ? new Date(r.createdAt).toLocaleDateString('en-US', { timeZone: 'UTC' }) : ''}</span>
                 </div>
                 <p className="mt-1 text-xs text-gray-600">By {getReviewerName(r)}</p>
                 {r.title ? <h4 className="font-medium mt-1">{r.title}</h4> : null}

--- a/src/app/(frontend)/my-orders/page.tsx
+++ b/src/app/(frontend)/my-orders/page.tsx
@@ -126,7 +126,7 @@ export default async function MyOrdersPage({
                     </Badge>
                   </div>
                   <CardDescription>
-                    Ordered: {new Date(order.orderDate).toLocaleDateString()}
+                    Ordered: {new Date(order.orderDate).toLocaleDateString('en-US', { timeZone: 'UTC' })}
                   </CardDescription>
                 </CardHeader>
 

--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -15,10 +15,11 @@ export default async function PrivacyPage() {
   const payload = await getPayload({ config: payloadConfig })
   const { user } = await payload.auth({ headers })
 
-  const updated = new Date().toLocaleDateString(undefined, {
+  const updated = new Date().toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: 'UTC',
   })
 
   return (

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -37,7 +37,7 @@ function Calendar({
       captionLayout={captionLayout}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString("default", { month: "short" }),
+          date.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' }),
         ...formatters,
       }}
       classNames={{
@@ -187,7 +187,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString()}
+      data-day={day.date.toLocaleDateString('en-US', { timeZone: 'UTC' })}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -234,7 +234,7 @@ function ChartTooltipContent({
                     </div>
                     {item.value && (
                       <span className="text-foreground font-mono font-medium tabular-nums">
-                        {item.value.toLocaleString()}
+                        {item.value.toLocaleString('en-US')}
                       </span>
                     )}
                   </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -606,9 +606,10 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean
 }) {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
+  // Random width between 50 to 90% after mount to avoid hydration mismatch.
+  const [width, setWidth] = React.useState('80%')
+  React.useEffect(() => {
+    setWidth(`${Math.floor(Math.random() * 40) + 50}%`)
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- render dates with fixed en-US locale and UTC timezone
- avoid server/client mismatch from random widths and number formatting

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c67a77a33c832a885bce63d8dbf387