### PR TITLE
Improve medium screen card button spacing

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -187,12 +187,13 @@ export default async function HomePage() {
                           </span>
                           <p className="text-xs text-gray-500 font-medium">Premium Quality</p>
                         </div>
-                        <div className="flex items-center gap-1 sm:gap-2">
-                          <AddToCartButton item={item} />
+                        <div className="flex items-center gap-1 sm:gap-2 md:flex-col md:items-stretch md:gap-2 lg:flex-row lg:items-center">
+                          <AddToCartButton item={item} className="md:w-full lg:w-auto" />
                           <OrderNowButton
                             item={item}
                             isLoggedIn={!!user}
-                            className="px-2 sm:px-4 py-2 text-xs sm:text-sm"
+                            className="px-2 sm:px-4 py-2 text-xs sm:text-sm md:w-full lg:w-auto"
+                            wrapperClassName="md:w-full lg:w-auto"
                           />
                         </div>
                       </CardFooter>

--- a/src/components/add-to-cart-button.tsx
+++ b/src/components/add-to-cart-button.tsx
@@ -6,6 +6,7 @@ import { Plus, Check } from 'lucide-react'
 import { useCart } from '@/lib/cart-context'
 import { Button } from '@/components/ui/button'
 import type { CartItem } from '@/lib/cart-context'
+import { cn } from '@/lib/utils'
 
 interface AddToCartButtonProps {
   item: {
@@ -19,9 +20,10 @@ interface AddToCartButtonProps {
     }
     imageUrl?: string
   }
+  className?: string
 }
 
-export const AddToCartButton: React.FC<AddToCartButtonProps> = ({ item }) => {
+export const AddToCartButton: React.FC<AddToCartButtonProps> = ({ item, className }) => {
   const { addItem, openCart } = useCart()
   const [isAdded, setIsAdded] = useState(false)
 
@@ -53,12 +55,13 @@ export const AddToCartButton: React.FC<AddToCartButtonProps> = ({ item }) => {
       onClick={handleAddToCart}
       disabled={isAdded}
       size="sm"
-      className={`
-        h-8 px-2 text-xs
-        sm:h-9 sm:px-4 sm:text-sm
-        md:h-10 md:px-6 md:text-base
-        ${isAdded ? 'bg-green-600 hover:bg-green-600' : ''}
-      `}
+      className={cn(
+        'h-8 px-2 text-xs',
+        'sm:h-9 sm:px-4 sm:text-sm',
+        'md:h-10 md:px-6 md:text-base',
+        isAdded && 'bg-green-600 hover:bg-green-600',
+        className,
+      )}
     >
       {isAdded ? (
         <>

--- a/src/components/order-now-button.tsx
+++ b/src/components/order-now-button.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 type Item = {
   id: string
@@ -18,10 +19,12 @@ type Item = {
 export function OrderNowButton({
   item,
   className = '',
+  wrapperClassName = '',
   isLoggedIn,
 }: {
   item: Item
   className?: string
+  wrapperClassName?: string
   isLoggedIn?: boolean
 }) {
   const [loading, setLoading] = useState(false)
@@ -87,12 +90,15 @@ export function OrderNowButton({
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className={cn('flex flex-col gap-2', wrapperClassName)}>
       <Button
         type="button"
         onClick={handleOrder}
         disabled={loading}
-        className={`bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white px-6 py-3 rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105 ${className}`}
+        className={cn(
+          'bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white px-6 py-3 rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105',
+          className,
+        )}
       >
         {loading ? 'Ordering…' : 'Order Now'}
       </Button>


### PR DESCRIPTION
## Summary
- allow passing custom class names to `AddToCartButton`
- extend `OrderNowButton` with wrapper class support
- stack cart and order buttons vertically on medium screens for better spacing

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c6cac8923c832ab4ad5c191bce0987