### PR TITLE
feat: add Google tag

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -36,6 +36,21 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
 
   return (
     <html lang="en">
+      <head>
+        {/* Google tag (gtag.js) */}
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q3LY08VXYN"></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+
+              gtag('config', 'G-Q3LY08VXYN');
+            `,
+          }}
+        />
+      </head>
       <body>
         <CartProvider>
           <main>{children}</main>


### PR DESCRIPTION
## Summary
- add Google Analytics tag to front-end layout

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c7550ee438832a819bcc6f839e928b