### PR TITLE
feat: track add to cart and purchase events

### DIFF
--- a/src/app/(frontend)/order-confirmation/ConfirmationClient.tsx
+++ b/src/app/(frontend)/order-confirmation/ConfirmationClient.tsx
@@ -35,6 +35,11 @@ export function ConfirmationClient({ orderId }: { orderId?: string }) {
   useEffect(() => {
     if (items) {
       track('purchase', { orderId, items })
+      try {
+        sessionStorage.removeItem('last-order-preview')
+      } catch {
+        // ignore
+      }
     }
   }, [items, orderId])
 

--- a/src/app/(frontend)/order-confirmation/ConfirmationClient.tsx
+++ b/src/app/(frontend)/order-confirmation/ConfirmationClient.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
+import { track } from '@/lib/tracking'
 
 type PreviewItem = {
   name?: string
@@ -30,6 +31,12 @@ export function ConfirmationClient({ orderId }: { orderId?: string }) {
       // ignore
     }
   }, [])
+
+  useEffect(() => {
+    if (items) {
+      track('purchase', { orderId, items })
+    }
+  }, [items, orderId])
 
   return (
     <>

--- a/src/components/add-to-cart-button.tsx
+++ b/src/components/add-to-cart-button.tsx
@@ -7,6 +7,7 @@ import { useCart } from '@/lib/cart-context'
 import { Button } from '@/components/ui/button'
 import type { CartItem } from '@/lib/cart-context'
 import { cn } from '@/lib/utils'
+import { track } from '@/lib/tracking'
 
 interface AddToCartButtonProps {
   item: {
@@ -38,6 +39,8 @@ export const AddToCartButton: React.FC<AddToCartButtonProps> = ({ item, classNam
           : (item as any).category,
       image: item.image || (item.imageUrl ? { url: item.imageUrl } : undefined),
     })
+
+    track('addToCart', { id: item.id, name: item.name, price: item.price })
 
     setIsAdded(true)
 

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,0 +1,6 @@
+export const track = (event: string, data?: Record<string, any>) => {
+  if (typeof window !== 'undefined') {
+    ;(window as any).dataLayer = (window as any).dataLayer || []
+    ;(window as any).dataLayer.push({ event, ...(data || {}) })
+  }
+}


### PR DESCRIPTION
## Summary
- add tracking utility for pushing events to GTM dataLayer
- fire addToCart event from cart button with item info
- send purchase event on order confirmation

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68c75a1292d0832aad4a5929f2d349c1