### PR TITLE
Fix truncated order button in product cards

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -187,13 +187,13 @@ export default async function HomePage() {
                           </span>
                           <p className="text-xs text-gray-500 font-medium">Premium Quality</p>
                         </div>
-                        <div className="flex items-center gap-1 sm:gap-2 md:flex-col md:items-stretch md:gap-2 lg:flex-row lg:items-center">
-                          <AddToCartButton item={item} className="md:w-full lg:w-auto" />
+                        <div className="flex flex-wrap items-center gap-1 sm:gap-2 md:flex-col md:items-stretch md:gap-2 lg:flex-row lg:flex-wrap lg:items-center">
+                          <AddToCartButton item={item} className="flex-shrink-0 md:w-full lg:w-auto" />
                           <OrderNowButton
                             item={item}
                             isLoggedIn={!!user}
-                            className="px-2 sm:px-4 py-2 text-xs sm:text-sm md:w-full lg:w-auto"
-                            wrapperClassName="md:w-full lg:w-auto"
+                            className="flex-shrink-0 px-2 sm:px-4 py-2 text-xs sm:text-sm md:w-full lg:w-auto"
+                            wrapperClassName="flex-shrink-0 md:w-full lg:w-auto"
                           />
                         </div>
                       </CardFooter>


### PR DESCRIPTION
## Summary
- Ensure product card actions wrap instead of being clipped
- Prevent Add to Cart and Order buttons from shrinking in narrow layouts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c7a1be1050832aa0f6174d45ffb507