### PR TITLE
Align action button sizes

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -187,13 +187,13 @@ export default async function HomePage() {
                           </span>
                           <p className="text-xs text-gray-500 font-medium">Premium Quality</p>
                         </div>
-                        <div className="ml-auto flex flex-wrap justify-end gap-1 sm:gap-2 md:flex-col md:items-end md:gap-2 lg:flex-row lg:flex-wrap lg:items-center">
-                          <AddToCartButton item={item} className="flex-shrink-0" />
+                        <div className="flex flex-1 flex-wrap justify-end gap-1 sm:gap-2 md:flex-col md:items-end md:gap-2 lg:flex-row lg:flex-wrap lg:items-center">
+                          <AddToCartButton item={item} className="flex-1" />
                           <OrderNowButton
                             item={item}
                             isLoggedIn={!!user}
-                            className="flex-shrink-0 px-2 sm:px-4 py-2 text-xs sm:text-sm"
-                            wrapperClassName="flex-shrink-0"
+                            className="w-full h-8 px-2 text-xs sm:h-9 sm:px-4 sm:text-sm md:h-10 md:px-6 md:text-base"
+                            wrapperClassName="flex-1"
                           />
                         </div>
                       </CardFooter>


### PR DESCRIPTION
## Summary
- Keep Add to Cart and Order Now buttons the same size in product cards

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68c7aa1aa7e0832aa79029e5cca2b911