### PR TITLE
Tweak cart and order button sizing

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -187,14 +187,9 @@ export default async function HomePage() {
                           </span>
                           <p className="text-xs text-gray-500 font-medium">Premium Quality</p>
                         </div>
-                        <div className="flex flex-1 flex-wrap justify-end gap-1 sm:gap-2 md:flex-col md:items-end md:gap-2 lg:flex-row lg:flex-wrap lg:items-center">
-                          <AddToCartButton item={item} className="flex-1" />
-                          <OrderNowButton
-                            item={item}
-                            isLoggedIn={!!user}
-                            className="w-full h-8 px-2 text-xs sm:h-9 sm:px-4 sm:text-sm md:h-10 md:px-6 md:text-base"
-                            wrapperClassName="flex-1"
-                          />
+                        <div className="flex flex-wrap justify-end gap-1 sm:gap-2 md:flex-col md:items-end md:gap-2 lg:flex-row lg:flex-wrap lg:items-center">
+                          <AddToCartButton item={item} />
+                          <OrderNowButton item={item} isLoggedIn={!!user} />
                         </div>
                       </CardFooter>
                     </div>

--- a/src/components/add-to-cart-button.tsx
+++ b/src/components/add-to-cart-button.tsx
@@ -59,21 +59,21 @@ export const AddToCartButton: React.FC<AddToCartButtonProps> = ({ item, classNam
       disabled={isAdded}
       size="sm"
       className={cn(
-        'h-8 px-2 text-xs',
-        'sm:h-9 sm:px-4 sm:text-sm',
-        'md:h-10 md:px-6 md:text-base',
+        'h-7 px-2 text-xs',
+        'sm:h-8 sm:px-3 sm:text-sm',
+        'md:h-9 md:px-4 md:text-sm',
         isAdded && 'bg-green-600 hover:bg-green-600',
         className,
       )}
     >
       {isAdded ? (
         <>
-          <Check className="h-3 w-3 sm:h-4 sm:w-4 md:h-5 md:w-5 mr-1 sm:mr-2 md:mr-3" />
+          <Check className="h-3 w-3 sm:h-3 sm:w-3 md:h-4 md:w-4 mr-1 sm:mr-1 md:mr-2" />
           <span>Added!</span>
         </>
       ) : (
         <>
-          <Plus className="h-3 w-3 sm:h-4 sm:w-4 md:h-5 md:w-5 mr-1 sm:mr-2 md:mr-3" />
+          <Plus className="h-3 w-3 sm:h-3 sm:w-3 md:h-4 md:w-4 mr-1 sm:mr-1 md:mr-2" />
           <span>Add to Cart</span>
         </>
       )}

--- a/src/components/order-now-button.tsx
+++ b/src/components/order-now-button.tsx
@@ -97,7 +97,7 @@ export function OrderNowButton({
         disabled={loading}
         size="sm"
         className={cn(
-          'bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105 h-7 px-2 text-xs sm:h-8 sm:px-3 sm:text-sm md:h-9 md:px-4 md:text-sm',
+          'bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105 h-7 px-3 text-xs sm:h-8 sm:px-4 sm:text-sm md:h-9 md:px-5 md:text-sm',
           className,
         )}
       >

--- a/src/components/order-now-button.tsx
+++ b/src/components/order-now-button.tsx
@@ -95,8 +95,9 @@ export function OrderNowButton({
         type="button"
         onClick={handleOrder}
         disabled={loading}
+        size="sm"
         className={cn(
-          'bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white px-6 py-3 rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105',
+          'bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105 h-7 px-2 text-xs sm:h-8 sm:px-3 sm:text-sm md:h-9 md:px-4 md:text-sm',
           className,
         )}
       >


### PR DESCRIPTION
## Summary
- reduce add to cart button height, padding, and icon size
- shrink order now button and apply smaller text and spacing
- drop flex growth so product card buttons size to their content

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c7ae50e3cc832aa36b99061f25d5d8