### PR TITLE
Increase mobile order and cart button heights

### DIFF
--- a/src/components/cart-button.tsx
+++ b/src/components/cart-button.tsx
@@ -11,8 +11,8 @@ export const CartButton: React.FC = () => {
   const totalItems = getTotalItems()
 
   return (
-    <Button variant="outline" size="sm" onClick={toggleCart} className="relative">
-      <ShoppingCart className="h-4 w-4" />
+    <Button variant="outline" size="sm" onClick={toggleCart} className="relative h-10 sm:h-8">
+      <ShoppingCart className="h-5 w-5 sm:h-4 sm:w-4" />
       {totalItems > 0 && (
         <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
           {totalItems}

--- a/src/components/order-now-button.tsx
+++ b/src/components/order-now-button.tsx
@@ -97,7 +97,7 @@ export function OrderNowButton({
         disabled={loading}
         size="sm"
         className={cn(
-          'bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105 h-7 px-3 text-xs sm:h-8 sm:px-4 sm:text-sm md:h-9 md:px-5 md:text-sm',
+          'bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105 h-10 px-3 text-xs sm:h-8 sm:px-4 sm:text-sm md:h-9 md:px-5 md:text-sm',
           className,
         )}
       >


### PR DESCRIPTION
## Summary
- enlarge `OrderNowButton` height on mobile for easier tapping
- expand cart button size and icon on small screens

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c7cac38504832a8db8caba869af6a9