### PR TITLE
Increase mobile button heights

### DIFF
--- a/src/components/add-to-cart-button.tsx
+++ b/src/components/add-to-cart-button.tsx
@@ -59,9 +59,9 @@ export const AddToCartButton: React.FC<AddToCartButtonProps> = ({ item, classNam
       disabled={isAdded}
       size="sm"
       className={cn(
-        'h-7 px-2 text-xs',
-        'sm:h-8 sm:px-3 sm:text-sm',
-        'md:h-9 md:px-4 md:text-sm',
+        'h-9 px-2 text-xs',
+        'sm:h-10 sm:px-3 sm:text-sm',
+        'md:h-11 md:px-4 md:text-sm',
         isAdded && 'bg-green-600 hover:bg-green-600',
         className,
       )}

--- a/src/components/order-now-button.tsx
+++ b/src/components/order-now-button.tsx
@@ -97,7 +97,7 @@ export function OrderNowButton({
         disabled={loading}
         size="sm"
         className={cn(
-          'bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105 h-7 px-3 text-xs sm:h-8 sm:px-4 sm:text-sm md:h-9 md:px-5 md:text-sm',
+          'bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105 h-9 px-3 text-xs sm:h-10 sm:px-4 sm:text-sm md:h-11 md:px-5 md:text-sm',
           className,
         )}
       >


### PR DESCRIPTION
## Summary
- enlarge default mobile height for Add to Cart button
- enlarge default mobile height for Order Now button

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c7cd3e400c832a8c7c42a595444e5d