### PR TITLE
Make site header blur responsive

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -30,7 +30,7 @@ export function SiteHeader({
   if (variant === 'full') {
     return (
       <header
-        className={`sticky top-0 z-50 w-full border-b border-gray-200/60 bg-white/80 backdrop-blur-2xl ${className}`}
+        className={`sticky top-0 z-50 w-full border-b border-gray-200/60 bg-white/80 backdrop-blur-none sm:backdrop-blur-2xl ${className}`}
       >
         <div className="container mx-auto flex h-20 items-center justify-between px-4 sm:px-6 lg:px-8">
           <Link href="/" className="flex items-center gap-3 group">
@@ -38,7 +38,7 @@ export function SiteHeader({
               <span className="text-3xl group-hover:scale-110 transition-transform duration-300">
                 🍿
               </span>
-              <div className="absolute inset-0 rounded-full blur-lg opacity-0 group-hover:opacity-40 transition-opacity duration-300 brand-glow"></div>
+              <div className="absolute inset-0 rounded-full blur-sm sm:blur-lg opacity-0 group-hover:opacity-30 sm:group-hover:opacity-40 transition-opacity duration-300 brand-glow"></div>
             </div>
             <h1 className="text-2xl font-bold brand-text tracking-tight">
               Online Bazar


### PR DESCRIPTION
## Summary
- avoid applying the heavy backdrop blur effect on the site header until the small breakpoint while keeping desktop visuals intact
- tone down the logo glow blur and opacity on sub-small viewports to reduce mobile paint work

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68ca044269c0832ab26ddd4e4d47de45