### PR TITLE
Avoid render-blocking email decode script

### DIFF
--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
+import dynamic from 'next/dynamic'
+
 import { SiteHeader } from '@/components/site-header'
+
+const ContactEmailLink = dynamic(() => import('@/components/contact-email-link'), {
+  ssr: false,
+  loading: () => <span className="text-gray-600">Email us</span>,
+})
 
 export const metadata = {
   title: 'Privacy Policy — Online Bazar',
@@ -73,7 +80,12 @@ export default function PrivacyPage() {
 
         <h2>Contact Us</h2>
         <p>
-          Email: <a href="mailto:rahmatullahzisan@gmail.com">rahmatullahzisan@gmail.com</a><br />
+          Email:{' '}
+          <ContactEmailLink className="hover:text-emerald-600" />{' '}
+          <noscript>
+            <span className="text-gray-600">rahmatullahzisan [at] gmail [dot] com</span>
+          </noscript>
+          <br />
           Phone: <a href="tel:01739416661">01739-416661</a><br />
           Facebook: <a href="https://www.facebook.com/onlinebazarbarguna" target="_blank" rel="noreferrer">@onlinebazarbarguna</a>
         </p>

--- a/src/components/contact-email-link.tsx
+++ b/src/components/contact-email-link.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { cn } from '@/lib/utils'
+
+type ContactEmailLinkProps = {
+  className?: string
+  label?: string
+}
+
+const EMAIL_PARTS = ['rahmatullahzisan', 'gmail', 'com'] as const
+
+export function ContactEmailLink({ className, label }: ContactEmailLinkProps) {
+  const email = useMemo(() => {
+    const [user, domain, tld] = EMAIL_PARTS
+    return `${user}@${domain}.${tld}`
+  }, [])
+
+  const href = useMemo(() => `mailto:${email}`, [email])
+
+  return (
+    <a
+      href={href}
+      className={cn(
+        'transition-colors hover:text-emerald-600 focus-visible:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50',
+        className,
+      )}
+      aria-label={`Email Online Bazar at ${email}`}
+    >
+      {label ?? email}
+    </a>
+  )
+}
+
+export default ContactEmailLink

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,5 +1,13 @@
 import React from 'react'
 import Link from 'next/link'
+import dynamic from 'next/dynamic'
+
+const ContactEmailLink = dynamic(() => import('@/components/contact-email-link'), {
+  ssr: false,
+  loading: () => (
+    <span className="text-gray-600">Email us</span>
+  ),
+})
 
 export function SiteFooter() {
   return (
@@ -39,7 +47,14 @@ export function SiteFooter() {
             <h4 className="text-sm font-semibold text-gray-900 tracking-wide">Contact</h4>
             <ul className="mt-3 space-y-2 text-sm text-gray-600">
               <li>Phone: <a href="tel:01739416661" className="hover:text-emerald-600">01739-416661</a></li>
-              <li>Email: <a href="mailto:rahmatullahzisan@gmail.com" className="hover:text-emerald-600">rahmatullahzisan@gmail.com</a></li>
+              <li>
+                Email:{' '}
+                <ContactEmailLink className="hover:text-emerald-600" />
+                {' '}
+                <noscript>
+                  <span className="text-gray-600">rahmatullahzisan [at] gmail [dot] com</span>
+                </noscript>
+              </li>
               <li>Facebook: <a href="https://www.facebook.com/onlinebazarbarguna" target="_blank" rel="noreferrer" className="hover:text-emerald-600">@onlinebazarbarguna</a></li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- add a client-only contact email link that assembles the address after hydration so Cloudflare no longer injects its blocking decoder script
- update the footer and privacy page contact sections to use the deferred link and provide noscript fallbacks for non-JavaScript visitors

## Testing
- pnpm lint (warnings only from existing files)


------
https://chatgpt.com/codex/tasks/task_b_68ca0c5ca8fc832aaa413539b7bed455