### PR TITLE
Wrap GTM scripts in conditional Script components

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Script from 'next/script'
 import type { Metadata } from 'next'
 
 import { CartProvider } from '@/lib/cart-context'
@@ -57,17 +58,26 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
         {blobHost ? <link rel="dns-prefetch" href={`//${blobHost}`} /> : null}
 
         {/* Google tag (gtag.js) - kept from your update */}
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q3LY08VXYN"></script>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);} 
-              gtag('js', new Date());
-              gtag('config', 'G-Q3LY08VXYN');
-            `,
-          }}
-        />
+        {enableAnalytics && (
+          <>
+            <Script
+              src="https://www.googletagmanager.com/gtag/js?id=G-Q3LY08VXYN"
+              strategy="afterInteractive"
+            />
+            <Script
+              id="gtag-init"
+              strategy="afterInteractive"
+              dangerouslySetInnerHTML={{
+                __html: `
+                  window.dataLayer = window.dataLayer || [];
+                  function gtag(){dataLayer.push(arguments);}
+                  gtag('js', new Date());
+                  gtag('config', 'G-Q3LY08VXYN');
+                `,
+              }}
+            />
+          </>
+        )}
       </head>
       <body>
         <CartProvider>


### PR DESCRIPTION
## Summary
- gate the Google Tag Manager loading and configuration scripts on the enableAnalytics flag
- switch the raw script tags to Next.js Script components so the bundle loads after interactive

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68ca497b27ac832ab9dc93b173ba2bb4