### PR TITLE
Add delivery settings relation to locked documents

### DIFF
--- a/src/migrations/20250917_add_delivery_settings_lock_rel.ts
+++ b/src/migrations/20250917_add_delivery_settings_lock_rel.ts
@@ -1,0 +1,67 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-vercel-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    -- Add delivery_settings_id to payload_locked_documents_rels for lock / relation tracking
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'payload_locked_documents_rels' AND column_name = 'delivery_settings_id'
+      ) THEN
+        ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "delivery_settings_id" integer;
+      END IF;
+    END $$;
+
+    -- Create index if missing
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'i' AND c.relname = 'payload_locked_documents_rels_delivery_settings_id_idx' AND n.nspname = 'public'
+      ) THEN
+        CREATE INDEX "payload_locked_documents_rels_delivery_settings_id_idx" ON "payload_locked_documents_rels" USING btree ("delivery_settings_id");
+      END IF;
+    END $$;
+
+    -- Add FK if missing
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_schema = 'public' AND table_name = 'payload_locked_documents_rels' AND constraint_name = 'payload_locked_documents_rels_delivery_settings_fk'
+      ) THEN
+        ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_delivery_settings_fk"
+          FOREIGN KEY ("delivery_settings_id") REFERENCES "public"."delivery_settings"("id") ON DELETE cascade ON UPDATE no action;
+      END IF;
+    END $$;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    -- Drop FK and index then column, if they exist
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_schema = 'public' AND table_name = 'payload_locked_documents_rels' AND constraint_name = 'payload_locked_documents_rels_delivery_settings_fk'
+      ) THEN
+        ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_delivery_settings_fk";
+      END IF;
+    END $$;
+
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_delivery_settings_id_idx";
+
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'payload_locked_documents_rels' AND column_name = 'delivery_settings_id'
+      ) THEN
+        ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "delivery_settings_id";
+      END IF;
+    END $$;
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -14,6 +14,7 @@ import * as migration_20250912_add_device_fields_to_orders from './20250912_add_
 import * as migration_20250913_add_abandoned_carts from './20250913_add_abandoned_carts';
 import * as migration_20250916_add_short_description_to_items from './20250916_add_short_description_to_items';
 import * as migration_20250917_add_delivery_settings from './20250917_add_delivery_settings';
+import * as migration_20250917_add_delivery_settings_lock_rel from './20250917_add_delivery_settings_lock_rel';
 
 export const migrations = [
   {
@@ -95,5 +96,10 @@ export const migrations = [
     up: migration_20250917_add_delivery_settings.up,
     down: migration_20250917_add_delivery_settings.down,
     name: '20250917_add_delivery_settings',
+  },
+  {
+    up: migration_20250917_add_delivery_settings_lock_rel.up,
+    down: migration_20250917_add_delivery_settings_lock_rel.down,
+    name: '20250917_add_delivery_settings_lock_rel',
   },
 ];


### PR DESCRIPTION
## Summary
- add a migration that backfills the payload_locked_documents_rels table with a delivery_settings_id column, index, and FK
- register the migration so payload runs it with the rest of the stack

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68ca8843820c832abdbe1bc6c92c6e2d