### PR TITLE
Add digital wallet payment options to checkout

### DIFF
--- a/public/payment/bkash.svg
+++ b/public/payment/bkash.svg
@@ -1,0 +1,14 @@
+<svg width="160" height="64" viewBox="0 0 160 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="156" height="60" rx="14" fill="url(#paint0_linear)" stroke="#F3C0DA" stroke-width="4" />
+  <path d="M48 20L70 12L88 28L70 44L48 36L54 28L48 20Z" fill="white" opacity="0.85" />
+  <path d="M54 28L68 24L78 32L68 40L54 36L58 32L54 28Z" fill="#E20074" opacity="0.85" />
+  <text x="95" y="35" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="white">
+    b<tspan fill="#FFE4F1">K</tspan><tspan fill="white">ash</tspan>
+  </text>
+  <defs>
+    <linearGradient id="paint0_linear" x1="0" y1="0" x2="160" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E20074" />
+      <stop offset="1" stop-color="#F06292" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/payment/cash-on-delivery.svg
+++ b/public/payment/cash-on-delivery.svg
@@ -1,0 +1,17 @@
+<svg width="160" height="64" viewBox="0 0 160 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="156" height="60" rx="14" fill="url(#paint0_linear)" stroke="#C8E6C9" stroke-width="4" />
+  <rect x="36" y="18" width="52" height="28" rx="8" fill="#2E7D32" opacity="0.9" />
+  <rect x="42" y="24" width="40" height="16" rx="6" fill="#A5D6A7" />
+  <path d="M52 32C52 29.7909 53.7909 28 56 28H68C70.2091 28 72 29.7909 72 32C72 34.2091 70.2091 36 68 36H56C53.7909 36 52 34.2091 52 32Z" fill="#2E7D32" />
+  <path d="M60 28V24" stroke="#2E7D32" stroke-width="2" stroke-linecap="round" />
+  <path d="M64 40V36" stroke="#2E7D32" stroke-width="2" stroke-linecap="round" />
+  <text x="96" y="36" font-family="'Inter', 'Segoe UI', sans-serif" font-size="20" font-weight="700" fill="#1B5E20">
+    Cash on Delivery
+  </text>
+  <defs>
+    <linearGradient id="paint0_linear" x1="0" y1="0" x2="160" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E8F5E9" />
+      <stop offset="1" stop-color="#C5E1A5" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/payment/nagad.svg
+++ b/public/payment/nagad.svg
@@ -1,0 +1,21 @@
+<svg width="160" height="64" viewBox="0 0 160 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="156" height="60" rx="14" fill="url(#paint0_linear)" stroke="#FFD6A8" stroke-width="4" />
+  <g filter="url(#shadow)">
+    <circle cx="52" cy="32" r="18" fill="#fff6e9" />
+    <path d="M52 16C60 16 66 22 66 32C66 42 60 48 52 48C44 48 38 42 38 32C38 22 44 16 52 16Z" fill="#EA580C" opacity="0.9" />
+    <path d="M46 26H55L58 32L55 38H46L43 32L46 26Z" fill="#FACC15" opacity="0.95" />
+    <path d="M55 22L60 32L55 42" stroke="#F97316" stroke-width="3" stroke-linecap="round" />
+  </g>
+  <text x="82" y="36" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#fff7ed">
+    Nagad
+  </text>
+  <defs>
+    <linearGradient id="paint0_linear" x1="0" y1="0" x2="160" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#EA580C" />
+      <stop offset="1" stop-color="#F97316" />
+    </linearGradient>
+    <filter id="shadow" x="30" y="10" width="44" height="44" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#E2580C" flood-opacity="0.4" />
+    </filter>
+  </defs>
+</svg>

--- a/src/app/(frontend)/checkout/checkout-form.tsx
+++ b/src/app/(frontend)/checkout/checkout-form.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image'
 
 import { useCart } from '@/lib/cart-context'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -25,6 +25,9 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [customerNumber, setCustomerNumber] = useState<string>(user?.customerNumber || '')
+  const [paymentMethod, setPaymentMethod] = useState<'cod' | 'bkash' | 'nagad'>('cod')
+  const [paymentSenderNumber, setPaymentSenderNumber] = useState<string>('')
+  const [paymentTransactionId, setPaymentTransactionId] = useState<string>('')
   const [firstName, setFirstName] = useState<string>(user?.firstName || '')
   const [lastName, setLastName] = useState<string>(user?.lastName || '')
   const [email, setEmail] = useState<string>(user?.email || '')
@@ -48,6 +51,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
   const total = subtotal + shippingCharge
   const formatCurrency = (value: number) => `Tk ${value.toFixed(2)}`
   const router = useRouter()
+  const requiresDigitalPaymentDetails = paymentMethod === 'bkash' || paymentMethod === 'nagad'
 
   // Persist guest details for abandoned cart tracking
   React.useEffect(() => {
@@ -104,6 +108,17 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
       return
     }
 
+    if (requiresDigitalPaymentDetails) {
+      if (!paymentSenderNumber.trim()) {
+        setError('Please provide the sender number used for the payment.')
+        return
+      }
+      if (!paymentTransactionId.trim()) {
+        setError('Please provide the transaction ID from your payment receipt.')
+        return
+      }
+    }
+
     setIsSubmitting(true)
     setError(null)
 
@@ -120,6 +135,9 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
           })),
           customerNumber,
           deliveryZone,
+          paymentMethod,
+          paymentSenderNumber: requiresDigitalPaymentDetails ? paymentSenderNumber.trim() : undefined,
+          paymentTransactionId: requiresDigitalPaymentDetails ? paymentTransactionId.trim() : undefined,
           ...(user
             ? {
                 // Use provided shipping if filled, otherwise API will fall back to user profile
@@ -407,6 +425,94 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
         ) : (
           <p className="text-xs text-gray-500">
             Free delivery applies automatically when your subtotal reaches {formatCurrency(settings.freeDeliveryThreshold)}.
+          </p>
+        )}
+      </div>
+
+      {/* Payment Method */}
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold">Payment method</h3>
+        <p className="text-sm text-gray-500">
+          Choose how you would like to pay. Digital wallet payments require a completed transfer before placing the order.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {([
+            { value: 'cod', label: 'Cash on Delivery', image: '/payment/cash-on-delivery.svg' },
+            { value: 'bkash', label: 'bKash', image: '/payment/bkash.svg' },
+            { value: 'nagad', label: 'Nagad', image: '/payment/nagad.svg' },
+          ] as const).map((option) => (
+              <label
+                key={option.value}
+                className={cn(
+                  'border rounded-lg p-3 cursor-pointer transition flex flex-col items-center gap-2 text-center focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500',
+                  paymentMethod === option.value ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200',
+                )}
+              >
+                <input
+                  type="radio"
+                  name="paymentMethod"
+                  value={option.value}
+                  checked={paymentMethod === option.value}
+                  onChange={() => {
+                    setPaymentMethod(option.value)
+                    if (option.value === 'cod') {
+                      setPaymentSenderNumber('')
+                      setPaymentTransactionId('')
+                    }
+                    setError(null)
+                  }}
+                  className="sr-only"
+                />
+                <div className="relative w-32 h-16">
+                  <Image src={option.image} alt={option.label} fill className="object-contain" sizes="128px" />
+                </div>
+                <span className="font-medium text-sm">{option.label}</span>
+              </label>
+            ))}
+        </div>
+
+        {requiresDigitalPaymentDetails ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label htmlFor="paymentSenderNumber" className="text-sm font-medium text-gray-700">
+                Sender wallet number
+              </label>
+              <input
+                id="paymentSenderNumber"
+                name="paymentSenderNumber"
+                type="tel"
+                value={paymentSenderNumber}
+                onChange={(e) => {
+                  setPaymentSenderNumber(e.target.value)
+                  setError(null)
+                }}
+                required={requiresDigitalPaymentDetails}
+                placeholder="e.g. 01XXXXXXXXX"
+                className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="paymentTransactionId" className="text-sm font-medium text-gray-700">
+                Transaction ID
+              </label>
+              <input
+                id="paymentTransactionId"
+                name="paymentTransactionId"
+                type="text"
+                value={paymentTransactionId}
+                onChange={(e) => {
+                  setPaymentTransactionId(e.target.value)
+                  setError(null)
+                }}
+                required={requiresDigitalPaymentDetails}
+                placeholder="e.g. TXN123456789"
+                className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+        ) : (
+          <p className="text-xs text-gray-500">
+            You can pay in cash when the delivery arrives.
           </p>
         )}
       </div>

--- a/src/app/(frontend)/my-orders/page.tsx
+++ b/src/app/(frontend)/my-orders/page.tsx
@@ -16,6 +16,19 @@ import { CancelOrderButton } from './CancelOrderButton'
 
 export const dynamic = 'force-dynamic'
 
+const formatPaymentMethod = (method?: string | null) => {
+  switch (method) {
+    case 'bkash':
+      return 'bKash'
+    case 'nagad':
+      return 'Nagad'
+    case 'cod':
+      return 'Cash on Delivery'
+    default:
+      return 'Cash on Delivery'
+  }
+}
+
 export default async function MyOrdersPage({
   searchParams,
 }: {
@@ -175,6 +188,26 @@ export default async function MyOrdersPage({
                     <span className="text-lg font-bold">
                       Total: ৳{order.totalAmount.toFixed(2)}
                     </span>
+                  </div>
+                  <div className="space-y-1 text-sm text-gray-600 mt-2">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">Payment method</span>
+                      <span>{formatPaymentMethod(order.paymentMethod)}</span>
+                    </div>
+                    {order.paymentSenderNumber && (
+                      <div className="flex items-center justify-between">
+                        <span>Sender number</span>
+                        <span className="font-medium">{order.paymentSenderNumber}</span>
+                      </div>
+                    )}
+                    {order.paymentTransactionId && (
+                      <div className="flex items-center justify-between">
+                        <span>Transaction ID</span>
+                        <span className="font-mono text-xs sm:text-sm break-all">
+                          {order.paymentTransactionId}
+                        </span>
+                      </div>
+                    )}
                   </div>
                   {order.status === 'pending' && (
                     <div className="text-right mt-4">

--- a/src/collections/Orders.ts
+++ b/src/collections/Orders.ts
@@ -96,7 +96,10 @@ export const Orders: CollectionConfig = {
         description: 'Wallet number used to send the payment',
         condition: (data) => data?.paymentMethod === 'bkash' || data?.paymentMethod === 'nagad',
       },
-      validate: (value, { siblingData }) => {
+      validate: (
+        value: unknown,
+        { siblingData }: { siblingData?: { paymentMethod?: 'cod' | 'bkash' | 'nagad' } },
+      ) => {
         if (siblingData?.paymentMethod === 'bkash' || siblingData?.paymentMethod === 'nagad') {
           return typeof value === 'string' && value.trim().length > 0
             ? true
@@ -114,7 +117,10 @@ export const Orders: CollectionConfig = {
         description: 'Reference ID from the mobile wallet payment',
         condition: (data) => data?.paymentMethod === 'bkash' || data?.paymentMethod === 'nagad',
       },
-      validate: (value, { siblingData }) => {
+      validate: (
+        value: unknown,
+        { siblingData }: { siblingData?: { paymentMethod?: 'cod' | 'bkash' | 'nagad' } },
+      ) => {
         if (siblingData?.paymentMethod === 'bkash' || siblingData?.paymentMethod === 'nagad') {
           return typeof value === 'string' && value.trim().length > 0
             ? true

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -113,6 +113,8 @@ export const seed = async ({
     // Create sample orders with different statuses
     const sampleOrderStatuses = ['pending', 'processing', 'shipped', 'completed', 'cancelled', 'refunded'] as const
 
+    const paymentMethods: Array<'cod' | 'bkash' | 'nagad'> = ['cod', 'bkash', 'nagad']
+
     const orderPromises = sampleOrderStatuses.map(async (status, index) => {
       if (!createdItems[index]) return null
 
@@ -121,6 +123,10 @@ export const seed = async ({
       const subtotal = Number(selectedItem?.price || 0) * quantity
       const shippingCharge = 0
       const totalAmount = subtotal + shippingCharge
+      const paymentMethod = paymentMethods[index % paymentMethods.length]
+      const paymentSenderNumber =
+        paymentMethod === 'cod' ? undefined : `01739-41${(6661 + index).toString().padStart(4, '0')}`
+      const paymentTransactionId = paymentMethod === 'cod' ? undefined : `TXN-SEED-${index + 1}`
 
       return payload.create({
         collection: 'orders',
@@ -134,6 +140,9 @@ export const seed = async ({
           subtotal,
           shippingCharge,
           totalAmount,
+          paymentMethod,
+          paymentSenderNumber,
+          paymentTransactionId,
           items: [
             {
               item: selectedItem.id,

--- a/src/migrations/20250918_add_payment_fields_to_orders.ts
+++ b/src/migrations/20250918_add_payment_fields_to_orders.ts
@@ -1,0 +1,59 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-vercel-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_method'
+      ) THEN
+        ALTER TABLE "orders" ADD COLUMN "payment_method" varchar DEFAULT 'cod'::varchar;
+        UPDATE "orders" SET "payment_method" = 'cod' WHERE "payment_method" IS NULL;
+        ALTER TABLE "orders" ALTER COLUMN "payment_method" SET NOT NULL;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_sender_number'
+      ) THEN
+        ALTER TABLE "orders" ADD COLUMN "payment_sender_number" varchar;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_transaction_id'
+      ) THEN
+        ALTER TABLE "orders" ADD COLUMN "payment_transaction_id" varchar;
+      END IF;
+    END $$;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_method'
+      ) THEN
+        ALTER TABLE "orders" DROP COLUMN "payment_method";
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_sender_number'
+      ) THEN
+        ALTER TABLE "orders" DROP COLUMN "payment_sender_number";
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_transaction_id'
+      ) THEN
+        ALTER TABLE "orders" DROP COLUMN "payment_transaction_id";
+      END IF;
+    END $$;
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -15,6 +15,7 @@ import * as migration_20250913_add_abandoned_carts from './20250913_add_abandone
 import * as migration_20250916_add_short_description_to_items from './20250916_add_short_description_to_items';
 import * as migration_20250917_add_delivery_settings from './20250917_add_delivery_settings';
 import * as migration_20250917_add_delivery_settings_lock_rel from './20250917_add_delivery_settings_lock_rel';
+import * as migration_20250918_add_payment_fields_to_orders from './20250918_add_payment_fields_to_orders';
 
 export const migrations = [
   {
@@ -101,5 +102,10 @@ export const migrations = [
     up: migration_20250917_add_delivery_settings_lock_rel.up,
     down: migration_20250917_add_delivery_settings_lock_rel.down,
     name: '20250917_add_delivery_settings_lock_rel',
+  },
+  {
+    up: migration_20250918_add_payment_fields_to_orders.up,
+    down: migration_20250918_add_payment_fields_to_orders.down,
+    name: '20250918_add_payment_fields_to_orders',
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -252,6 +252,9 @@ export interface Order {
    * Customer contact number captured at time of order
    */
   customerNumber: string;
+  paymentMethod: 'cod' | 'bkash' | 'nagad';
+  paymentSenderNumber?: string | null;
+  paymentTransactionId?: string | null;
   items: {
     item: number | Item;
     quantity: number;
@@ -525,6 +528,9 @@ export interface OrdersSelect<T extends boolean = true> {
   customerName?: T;
   customerEmail?: T;
   customerNumber?: T;
+  paymentMethod?: T;
+  paymentSenderNumber?: T;
+  paymentTransactionId?: T;
   items?:
     | T
     | {


### PR DESCRIPTION
## Summary
- add selectable payment methods with wallet-specific fields and branded logos on the checkout page
- persist payment method metadata on orders with validation, migrations, and admin/email visibility
- expose payment details in order history and analytics while shipping new wallet logos

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68ca8d8c96fc832ab668957b31c89f31