### PR TITLE
Remove unused PNG payment logos

### DIFF
--- a/src/app/(frontend)/checkout/checkout-form.tsx
+++ b/src/app/(frontend)/checkout/checkout-form.tsx
@@ -7,13 +7,18 @@ import Image from 'next/image'
 
 import { useCart } from '@/lib/cart-context'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import type { DeliverySettings } from '@/lib/delivery-settings'
 import { DEFAULT_DELIVERY_SETTINGS } from '@/lib/delivery-settings'
 import { cn } from '@/lib/utils'
+import {
+  PAYMENT_OPTIONS,
+  type PaymentMethod,
+  isDigitalPaymentMethod,
+} from '@/lib/payment-options'
 
 interface CheckoutFormProps {
   user?: any
@@ -25,6 +30,9 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [customerNumber, setCustomerNumber] = useState<string>(user?.customerNumber || '')
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cod')
+  const [paymentSenderNumber, setPaymentSenderNumber] = useState<string>('')
+  const [paymentTransactionId, setPaymentTransactionId] = useState<string>('')
   const [firstName, setFirstName] = useState<string>(user?.firstName || '')
   const [lastName, setLastName] = useState<string>(user?.lastName || '')
   const [email, setEmail] = useState<string>(user?.email || '')
@@ -48,6 +56,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
   const total = subtotal + shippingCharge
   const formatCurrency = (value: number) => `Tk ${value.toFixed(2)}`
   const router = useRouter()
+  const requiresDigitalPaymentDetails = isDigitalPaymentMethod(paymentMethod)
 
   // Persist guest details for abandoned cart tracking
   React.useEffect(() => {
@@ -104,6 +113,17 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
       return
     }
 
+    if (requiresDigitalPaymentDetails) {
+      if (!paymentSenderNumber.trim()) {
+        setError('Please provide the sender number used for the payment.')
+        return
+      }
+      if (!paymentTransactionId.trim()) {
+        setError('Please provide the transaction ID from your payment receipt.')
+        return
+      }
+    }
+
     setIsSubmitting(true)
     setError(null)
 
@@ -120,6 +140,9 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
           })),
           customerNumber,
           deliveryZone,
+          paymentMethod,
+          paymentSenderNumber: requiresDigitalPaymentDetails ? paymentSenderNumber.trim() : undefined,
+          paymentTransactionId: requiresDigitalPaymentDetails ? paymentTransactionId.trim() : undefined,
           ...(user
             ? {
                 // Use provided shipping if filled, otherwise API will fall back to user profile
@@ -168,6 +191,9 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
             totalAmount: result?.doc?.totalAmount ?? total,
             deliveryZone: result?.doc?.deliveryZone ?? deliveryZone,
             freeDeliveryApplied: result?.doc?.freeDeliveryApplied ?? freeDelivery,
+            paymentMethod,
+            paymentSenderNumber: requiresDigitalPaymentDetails ? paymentSenderNumber.trim() : undefined,
+            paymentTransactionId: requiresDigitalPaymentDetails ? paymentTransactionId.trim() : undefined,
           }),
         )
       } catch {}
@@ -407,6 +433,98 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
         ) : (
           <p className="text-xs text-gray-500">
             Free delivery applies automatically when your subtotal reaches {formatCurrency(settings.freeDeliveryThreshold)}.
+          </p>
+        )}
+      </div>
+
+      {/* Payment Method */}
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold">Payment method</h3>
+        <p className="text-sm text-gray-500">
+          Choose how you would like to pay. Digital wallet payments require a completed transfer before placing the order.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {PAYMENT_OPTIONS.map((option) => (
+            <label
+              key={option.value}
+              className={cn(
+                  'border rounded-lg p-3 cursor-pointer transition flex flex-col items-center gap-2 text-center focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500',
+                  paymentMethod === option.value ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200',
+                )}
+              >
+                <input
+                  type="radio"
+                  name="paymentMethod"
+                  value={option.value}
+                  checked={paymentMethod === option.value}
+                  onChange={() => {
+                    setPaymentMethod(option.value)
+                    if (option.value === 'cod') {
+                      setPaymentSenderNumber('')
+                      setPaymentTransactionId('')
+                    }
+                    setError(null)
+                  }}
+                  className="sr-only"
+                />
+                <div className="relative w-32 h-16">
+                  <Image
+                    src={option.logo.src}
+                    alt={option.logo.alt}
+                    width={option.logo.width}
+                    height={option.logo.height}
+                    className="h-full w-full object-contain"
+                    sizes="128px"
+                    priority={option.value === 'cod'}
+                  />
+                </div>
+                <span className="font-medium text-sm">{option.label}</span>
+              </label>
+          ))}
+        </div>
+
+        {requiresDigitalPaymentDetails ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label htmlFor="paymentSenderNumber" className="text-sm font-medium text-gray-700">
+                Sender wallet number
+              </label>
+              <input
+                id="paymentSenderNumber"
+                name="paymentSenderNumber"
+                type="tel"
+                value={paymentSenderNumber}
+                onChange={(e) => {
+                  setPaymentSenderNumber(e.target.value)
+                  setError(null)
+                }}
+                required={requiresDigitalPaymentDetails}
+                placeholder="e.g. 01XXXXXXXXX"
+                className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="paymentTransactionId" className="text-sm font-medium text-gray-700">
+                Transaction ID
+              </label>
+              <input
+                id="paymentTransactionId"
+                name="paymentTransactionId"
+                type="text"
+                value={paymentTransactionId}
+                onChange={(e) => {
+                  setPaymentTransactionId(e.target.value)
+                  setError(null)
+                }}
+                required={requiresDigitalPaymentDetails}
+                placeholder="e.g. TXN123456789"
+                className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+        ) : (
+          <p className="text-xs text-gray-500">
+            You can pay in cash when the delivery arrives.
           </p>
         )}
       </div>

--- a/src/app/(frontend)/my-orders/page.tsx
+++ b/src/app/(frontend)/my-orders/page.tsx
@@ -16,6 +16,19 @@ import { CancelOrderButton } from './CancelOrderButton'
 
 export const dynamic = 'force-dynamic'
 
+const formatPaymentMethod = (method?: string | null) => {
+  switch (method) {
+    case 'bkash':
+      return 'bKash'
+    case 'nagad':
+      return 'Nagad'
+    case 'cod':
+      return 'Cash on Delivery'
+    default:
+      return 'Cash on Delivery'
+  }
+}
+
 export default async function MyOrdersPage({
   searchParams,
 }: {
@@ -175,6 +188,26 @@ export default async function MyOrdersPage({
                     <span className="text-lg font-bold">
                       Total: ৳{order.totalAmount.toFixed(2)}
                     </span>
+                  </div>
+                  <div className="space-y-1 text-sm text-gray-600 mt-2">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">Payment method</span>
+                      <span>{formatPaymentMethod(order.paymentMethod)}</span>
+                    </div>
+                    {order.paymentSenderNumber && (
+                      <div className="flex items-center justify-between">
+                        <span>Sender number</span>
+                        <span className="font-medium">{order.paymentSenderNumber}</span>
+                      </div>
+                    )}
+                    {order.paymentTransactionId && (
+                      <div className="flex items-center justify-between">
+                        <span>Transaction ID</span>
+                        <span className="font-mono text-xs sm:text-sm break-all">
+                          {order.paymentTransactionId}
+                        </span>
+                      </div>
+                    )}
                   </div>
                   {order.status === 'pending' && (
                     <div className="text-right mt-4">

--- a/src/app/(frontend)/order-confirmation/ConfirmationClient.tsx
+++ b/src/app/(frontend)/order-confirmation/ConfirmationClient.tsx
@@ -22,6 +22,9 @@ type PreviewData = {
   totalAmount?: number
   deliveryZone?: string
   freeDeliveryApplied?: boolean
+  paymentMethod?: 'cod' | 'bkash' | 'nagad'
+  paymentSenderNumber?: string
+  paymentTransactionId?: string
 }
 
 const toPositiveNumber = (value: unknown): number | undefined => {
@@ -54,6 +57,11 @@ export function ConfirmationClient({ orderId }: { orderId?: string }) {
             typeof parsed?.freeDeliveryApplied === 'boolean'
               ? Boolean(parsed.freeDeliveryApplied)
               : undefined,
+          paymentMethod: parsed?.paymentMethod,
+          paymentSenderNumber:
+            typeof parsed?.paymentSenderNumber === 'string' ? parsed.paymentSenderNumber : undefined,
+          paymentTransactionId:
+            typeof parsed?.paymentTransactionId === 'string' ? parsed.paymentTransactionId : undefined,
         })
       }
     } catch {
@@ -84,6 +92,16 @@ export function ConfirmationClient({ orderId }: { orderId?: string }) {
   const freeDelivery = preview?.freeDeliveryApplied ?? shipping === 0
   const deliveryZoneLabel =
     preview?.deliveryZone === 'outside_dhaka' ? 'Outside Dhaka' : 'Inside Dhaka'
+  const paymentLabel = (() => {
+    switch (preview?.paymentMethod) {
+      case 'bkash':
+        return 'bKash'
+      case 'nagad':
+        return 'Nagad'
+      default:
+        return 'Cash on Delivery'
+    }
+  })()
 
   return (
     <>
@@ -144,6 +162,22 @@ export function ConfirmationClient({ orderId }: { orderId?: string }) {
               <span>Total</span>
               <span>{formatCurrency(total)}</span>
             </div>
+            <div className="flex items-center justify-between">
+              <span>Payment method</span>
+              <span>{paymentLabel}</span>
+            </div>
+            {preview?.paymentSenderNumber ? (
+              <div className="flex items-center justify-between text-xs sm:text-sm">
+                <span>Sender number</span>
+                <span className="font-medium">{preview.paymentSenderNumber}</span>
+              </div>
+            ) : null}
+            {preview?.paymentTransactionId ? (
+              <div className="flex items-center justify-between text-xs sm:text-sm">
+                <span>Transaction ID</span>
+                <span className="font-mono break-all">{preview.paymentTransactionId}</span>
+              </div>
+            ) : null}
             {freeDelivery ? (
               <p className="text-xs text-green-600 font-semibold">Free delivery applied for this order.</p>
             ) : (

--- a/src/app/(frontend)/order/[id]/order-form.tsx
+++ b/src/app/(frontend)/order/[id]/order-form.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -9,6 +10,11 @@ import { Separator } from '@/components/ui/separator'
 import type { DeliverySettings } from '@/lib/delivery-settings'
 import { DEFAULT_DELIVERY_SETTINGS } from '@/lib/delivery-settings'
 import { cn } from '@/lib/utils'
+import {
+  PAYMENT_OPTIONS,
+  type PaymentMethod,
+  isDigitalPaymentMethod,
+} from '@/lib/payment-options'
 
 interface OrderFormProps {
   item: any
@@ -21,6 +27,9 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [customerNumber, setCustomerNumber] = useState<string>(user?.customerNumber || '')
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cod')
+  const [paymentSenderNumber, setPaymentSenderNumber] = useState('')
+  const [paymentTransactionId, setPaymentTransactionId] = useState('')
   const [firstName, setFirstName] = useState<string>(user?.firstName || '')
   const [lastName, setLastName] = useState<string>(user?.lastName || '')
   const [email, setEmail] = useState<string>(user?.email || '')
@@ -44,12 +53,27 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
   const total = subtotal + shippingCharge
   const formatCurrency = (value: number) => `Tk ${value.toFixed(2)}`
   const router = useRouter()
+  const requiresDigitalPaymentDetails = isDigitalPaymentMethod(paymentMethod)
 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsSubmitting(true)
     setError('')
+
+    if (requiresDigitalPaymentDetails) {
+      if (!paymentSenderNumber.trim()) {
+        setError('Please provide the sender number used for the payment.')
+        setIsSubmitting(false)
+        return
+      }
+
+      if (!paymentTransactionId.trim()) {
+        setError('Please provide the transaction ID from your payment receipt.')
+        setIsSubmitting(false)
+        return
+      }
+    }
 
     try {
       const response = await fetch('/api/orders', {
@@ -66,6 +90,9 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
           ],
           customerNumber,
           deliveryZone,
+          paymentMethod,
+          paymentSenderNumber: requiresDigitalPaymentDetails ? paymentSenderNumber.trim() : undefined,
+          paymentTransactionId: requiresDigitalPaymentDetails ? paymentTransactionId.trim() : undefined,
           ...(user
             ? {
                 // Optional override shipping
@@ -115,6 +142,9 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
               subtotal: (data as any)?.doc?.subtotal ?? subtotal,
               shippingCharge: (data as any)?.doc?.shippingCharge ?? shippingCharge,
               totalAmount: (data as any)?.doc?.totalAmount ?? total,
+              paymentMethod,
+              paymentSenderNumber: requiresDigitalPaymentDetails ? paymentSenderNumber.trim() : undefined,
+              paymentTransactionId: requiresDigitalPaymentDetails ? paymentTransactionId.trim() : undefined,
               deliveryZone: (data as any)?.doc?.deliveryZone ?? deliveryZone,
               freeDeliveryApplied: (data as any)?.doc?.freeDeliveryApplied ?? freeDelivery,
             }),
@@ -278,15 +308,103 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
             <div className="font-medium">Outside Dhaka</div>
             <p className="text-sm text-gray-500">Delivery charge {formatCurrency(settings.outsideDhakaCharge)}</p>
           </label>
-        </div>
-        {freeDelivery ? (
-          <p className="text-sm text-green-600 font-semibold">Free delivery applied for this order.</p>
-        ) : (
-          <p className="text-xs text-gray-500">
-            Free delivery applies automatically when your subtotal reaches {formatCurrency(settings.freeDeliveryThreshold)}.
-          </p>
-        )}
       </div>
+      {freeDelivery ? (
+        <p className="text-sm text-green-600 font-semibold">Free delivery applied for this order.</p>
+      ) : (
+        <p className="text-xs text-gray-500">
+          Free delivery applies automatically when your subtotal reaches {formatCurrency(settings.freeDeliveryThreshold)}.
+        </p>
+      )}
+    </div>
+
+    {/* Payment Method */}
+    <div className="space-y-3">
+      <h3 className="text-lg font-semibold">Payment method</h3>
+      <p className="text-sm text-gray-500">
+        Choose how you would like to pay. Digital wallet payments require a completed transfer before placing the order.
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {PAYMENT_OPTIONS.map((option) => (
+          <label
+            key={option.value}
+            className={cn(
+              'border rounded-lg p-3 cursor-pointer transition flex flex-col items-center gap-2 text-center focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500',
+              paymentMethod === option.value ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200',
+            )}
+          >
+            <input
+              type="radio"
+              name="paymentMethod"
+              value={option.value}
+              checked={paymentMethod === option.value}
+              onChange={() => {
+                setPaymentMethod(option.value)
+                if (option.value === 'cod') {
+                  setPaymentSenderNumber('')
+                  setPaymentTransactionId('')
+                }
+                setError('')
+              }}
+              className="sr-only"
+            />
+            <div className="relative w-32 h-16">
+              <Image
+                src={option.logo.src}
+                alt={option.logo.alt}
+                width={option.logo.width}
+                height={option.logo.height}
+                className="h-full w-full object-contain"
+                sizes="128px"
+                priority={option.value === 'cod'}
+              />
+            </div>
+            <span className="font-medium text-sm">{option.label}</span>
+          </label>
+        ))}
+      </div>
+
+      {requiresDigitalPaymentDetails ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <label htmlFor="paymentSenderNumber" className="text-sm font-medium text-gray-700">
+              Sender wallet number
+            </label>
+            <Input
+              id="paymentSenderNumber"
+              name="paymentSenderNumber"
+              type="tel"
+              value={paymentSenderNumber}
+              onChange={(e) => {
+                setPaymentSenderNumber(e.target.value)
+                setError('')
+              }}
+              required={requiresDigitalPaymentDetails}
+              placeholder="e.g. 01XXXXXXXXX"
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="paymentTransactionId" className="text-sm font-medium text-gray-700">
+              Transaction ID
+            </label>
+            <Input
+              id="paymentTransactionId"
+              name="paymentTransactionId"
+              type="text"
+              value={paymentTransactionId}
+              onChange={(e) => {
+                setPaymentTransactionId(e.target.value)
+                setError('')
+              }}
+              required={requiresDigitalPaymentDetails}
+              placeholder="e.g. TXN123456789"
+            />
+          </div>
+        </div>
+      ) : (
+        <p className="text-xs text-gray-500">You can pay in cash when the delivery arrives.</p>
+      )}
+    </div>
       <Separator />
 
       <div className="space-y-3">

--- a/src/collections/Orders.ts
+++ b/src/collections/Orders.ts
@@ -76,6 +76,60 @@ export const Orders: CollectionConfig = {
       },
     },
     {
+      name: 'paymentMethod',
+      type: 'select',
+      label: 'Payment method',
+      required: true,
+      defaultValue: 'cod',
+      options: [
+        { label: 'Cash on Delivery', value: 'cod' },
+        { label: 'bKash', value: 'bkash' },
+        { label: 'Nagad', value: 'nagad' },
+      ],
+    },
+    {
+      name: 'paymentSenderNumber',
+      type: 'text',
+      label: 'Sender wallet number',
+      required: false,
+      admin: {
+        description: 'Wallet number used to send the payment',
+        condition: (data) => data?.paymentMethod === 'bkash' || data?.paymentMethod === 'nagad',
+      },
+      validate: (
+        value: unknown,
+        { siblingData }: { siblingData?: { paymentMethod?: 'cod' | 'bkash' | 'nagad' } },
+      ) => {
+        if (siblingData?.paymentMethod === 'bkash' || siblingData?.paymentMethod === 'nagad') {
+          return typeof value === 'string' && value.trim().length > 0
+            ? true
+            : 'Sender wallet number is required for digital payments'
+        }
+        return true
+      },
+    },
+    {
+      name: 'paymentTransactionId',
+      type: 'text',
+      label: 'Transaction ID',
+      required: false,
+      admin: {
+        description: 'Reference ID from the mobile wallet payment',
+        condition: (data) => data?.paymentMethod === 'bkash' || data?.paymentMethod === 'nagad',
+      },
+      validate: (
+        value: unknown,
+        { siblingData }: { siblingData?: { paymentMethod?: 'cod' | 'bkash' | 'nagad' } },
+      ) => {
+        if (siblingData?.paymentMethod === 'bkash' || siblingData?.paymentMethod === 'nagad') {
+          return typeof value === 'string' && value.trim().length > 0
+            ? true
+            : 'Transaction ID is required for digital payments'
+        }
+        return true
+      },
+    },
+    {
       name: 'items',
       type: 'array',
       fields: [
@@ -251,6 +305,21 @@ export const Orders: CollectionConfig = {
           const total = Number((doc as any).totalAmount || 0)
           const customerName = String((doc as any).customerName || '')
           const customerEmail = String((doc as any).customerEmail || '')
+          const paymentMethodRaw = String((doc as any).paymentMethod || 'cod')
+          const paymentSenderNumber = String((doc as any).paymentSenderNumber || '')
+          const paymentTransactionId = String((doc as any).paymentTransactionId || '')
+          const formatPaymentLabel = (method: string) => {
+            switch (method) {
+              case 'bkash':
+                return 'bKash'
+              case 'nagad':
+                return 'Nagad'
+              case 'cod':
+              default:
+                return 'Cash on Delivery'
+            }
+          }
+          const paymentLabel = formatPaymentLabel(paymentMethodRaw)
           const orderAdminURL = serverURL ? `${serverURL}/admin/collections/orders/${orderId}` : ''
           const companyName = process.env.EMAIL_DEFAULT_FROM_NAME || 'Online Bazar'
 
@@ -298,6 +367,9 @@ export const Orders: CollectionConfig = {
               </table>
 
               <p style="margin-top:12px;"><strong>মোট মূল্য:</strong> ${fmt(total)}</p>
+              <p style="margin-top:12px;"><strong>পেমেন্ট:</strong> ${paymentLabel}${
+                paymentSenderNumber ? ` (Sender: ${paymentSenderNumber})` : ''
+              }${paymentTransactionId ? `, Txn: ${paymentTransactionId}` : ''}</p>
 
               <h3 style="margin:16px 0 8px 0;">যে ঠিকানায় পাঠানো হবে:</h3>
               <p>${addressLines.map((l: string) => l.replace(/</g, '&lt;').replace(/>/g, '&gt;')).join('<br/>')}</p>
@@ -351,28 +423,34 @@ export const Orders: CollectionConfig = {
           const adminEmail = process.env.ORDER_NOTIFICATIONS_EMAIL || process.env.GMAIL_USER
           if (adminEmail) {
             const adminLines = detailed.map((d) => `- ${d.name} x ${d.quantity}`).join('\n')
-            const adminText = [
-              `New order #${orderId} from ${customerName} <${customerEmail}>`,
-              '',
-              'Order summary:',
-              adminLines,
-              '',
-              `Total: ${total.toFixed(2)}`,
-              orderAdminURL ? `\nAdmin link: ${orderAdminURL}` : '',
-            ].filter(Boolean).join('\n')
+          const adminText = [
+            `New order #${orderId} from ${customerName} <${customerEmail}>`,
+            '',
+            'Order summary:',
+            adminLines,
+            '',
+            `Total: ${total.toFixed(2)}`,
+            `Payment: ${paymentLabel}`,
+            paymentSenderNumber ? `Sender: ${paymentSenderNumber}` : '',
+            paymentTransactionId ? `Txn: ${paymentTransactionId}` : '',
+            orderAdminURL ? `\nAdmin link: ${orderAdminURL}` : '',
+          ].filter(Boolean).join('\n')
 
-            const adminHTML = `
-              <div>
-                <p><strong>New order #${orderId}</strong></p>
-                <p>Customer: ${customerName} &lt;${customerEmail}&gt;</p>
-                <p><strong>Order summary:</strong></p>
-                <ul>
-                  ${detailed.map((d) => `<li>${d.name} x ${d.quantity}</li>`).join('')}
-                </ul>
-                <p><strong>Total:</strong> ${total.toFixed(2)}</p>
-                ${orderAdminURL ? `<p><a href="${orderAdminURL}">Open in Admin</a></p>` : ''}
-              </div>
-            `
+          const adminHTML = `
+            <div>
+              <p><strong>New order #${orderId}</strong></p>
+              <p>Customer: ${customerName} &lt;${customerEmail}&gt;</p>
+              <p><strong>Order summary:</strong></p>
+              <ul>
+                ${detailed.map((d) => `<li>${d.name} x ${d.quantity}</li>`).join('')}
+              </ul>
+              <p><strong>Total:</strong> ${total.toFixed(2)}</p>
+              <p><strong>Payment:</strong> ${paymentLabel}</p>
+              ${paymentSenderNumber ? `<p><strong>Sender:</strong> ${paymentSenderNumber}</p>` : ''}
+              ${paymentTransactionId ? `<p><strong>Transaction:</strong> ${paymentTransactionId}</p>` : ''}
+              ${orderAdminURL ? `<p><a href="${orderAdminURL}">Open in Admin</a></p>` : ''}
+            </div>
+          `
 
             await payload?.sendEmail?.({
               to: adminEmail,

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -113,6 +113,8 @@ export const seed = async ({
     // Create sample orders with different statuses
     const sampleOrderStatuses = ['pending', 'processing', 'shipped', 'completed', 'cancelled', 'refunded'] as const
 
+    const paymentMethods: Array<'cod' | 'bkash' | 'nagad'> = ['cod', 'bkash', 'nagad']
+
     const orderPromises = sampleOrderStatuses.map(async (status, index) => {
       if (!createdItems[index]) return null
 
@@ -121,6 +123,10 @@ export const seed = async ({
       const subtotal = Number(selectedItem?.price || 0) * quantity
       const shippingCharge = 0
       const totalAmount = subtotal + shippingCharge
+      const paymentMethod = paymentMethods[index % paymentMethods.length]
+      const paymentSenderNumber =
+        paymentMethod === 'cod' ? undefined : `01739-41${(6661 + index).toString().padStart(4, '0')}`
+      const paymentTransactionId = paymentMethod === 'cod' ? undefined : `TXN-SEED-${index + 1}`
 
       return payload.create({
         collection: 'orders',
@@ -134,6 +140,9 @@ export const seed = async ({
           subtotal,
           shippingCharge,
           totalAmount,
+          paymentMethod,
+          paymentSenderNumber,
+          paymentTransactionId,
           items: [
             {
               item: selectedItem.id,

--- a/src/lib/payment-options.ts
+++ b/src/lib/payment-options.ts
@@ -1,0 +1,58 @@
+export type PaymentMethod = 'cod' | 'bkash' | 'nagad'
+
+export interface PaymentLogo {
+  src: string
+  alt: string
+  width: number
+  height: number
+}
+
+export interface PaymentOption {
+  value: PaymentMethod
+  label: string
+  logo: PaymentLogo
+}
+
+export const DIGITAL_PAYMENT_METHODS: PaymentMethod[] = ['bkash', 'nagad']
+
+export const isDigitalPaymentMethod = (method: PaymentMethod): boolean =>
+  DIGITAL_PAYMENT_METHODS.includes(method)
+
+export const PAYMENT_OPTIONS: PaymentOption[] = [
+  {
+    value: 'cod',
+    label: 'Cash on Delivery',
+    logo: {
+      src: '/payment/cod.svg',
+      alt: 'Cash on Delivery logo',
+      width: 512,
+      height: 256,
+    },
+  },
+  {
+    value: 'bkash',
+    label: 'bKash',
+    logo: {
+      src: '/payment/bkash.svg',
+      alt: 'bKash logo',
+      width: 512,
+      height: 341,
+    },
+  },
+  {
+    value: 'nagad',
+    label: 'Nagad',
+    logo: {
+      src: '/payment/nagad.svg',
+      alt: 'Nagad logo',
+      width: 512,
+      height: 341,
+    },
+  },
+]
+
+export const PAYMENT_OPTION_MAP: Record<PaymentMethod, PaymentOption> =
+  PAYMENT_OPTIONS.reduce((acc, option) => {
+    acc[option.value] = option
+    return acc
+  }, {} as Record<PaymentMethod, PaymentOption>)

--- a/src/migrations/20250918_add_payment_fields_to_orders.ts
+++ b/src/migrations/20250918_add_payment_fields_to_orders.ts
@@ -1,0 +1,59 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-vercel-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_method'
+      ) THEN
+        ALTER TABLE "orders" ADD COLUMN "payment_method" varchar DEFAULT 'cod'::varchar;
+        UPDATE "orders" SET "payment_method" = 'cod' WHERE "payment_method" IS NULL;
+        ALTER TABLE "orders" ALTER COLUMN "payment_method" SET NOT NULL;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_sender_number'
+      ) THEN
+        ALTER TABLE "orders" ADD COLUMN "payment_sender_number" varchar;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_transaction_id'
+      ) THEN
+        ALTER TABLE "orders" ADD COLUMN "payment_transaction_id" varchar;
+      END IF;
+    END $$;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_method'
+      ) THEN
+        ALTER TABLE "orders" DROP COLUMN "payment_method";
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_sender_number'
+      ) THEN
+        ALTER TABLE "orders" DROP COLUMN "payment_sender_number";
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'orders' AND column_name = 'payment_transaction_id'
+      ) THEN
+        ALTER TABLE "orders" DROP COLUMN "payment_transaction_id";
+      END IF;
+    END $$;
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -15,6 +15,7 @@ import * as migration_20250913_add_abandoned_carts from './20250913_add_abandone
 import * as migration_20250916_add_short_description_to_items from './20250916_add_short_description_to_items';
 import * as migration_20250917_add_delivery_settings from './20250917_add_delivery_settings';
 import * as migration_20250917_add_delivery_settings_lock_rel from './20250917_add_delivery_settings_lock_rel';
+import * as migration_20250918_add_payment_fields_to_orders from './20250918_add_payment_fields_to_orders';
 
 export const migrations = [
   {
@@ -101,5 +102,10 @@ export const migrations = [
     up: migration_20250917_add_delivery_settings_lock_rel.up,
     down: migration_20250917_add_delivery_settings_lock_rel.down,
     name: '20250917_add_delivery_settings_lock_rel',
+  },
+  {
+    up: migration_20250918_add_payment_fields_to_orders.up,
+    down: migration_20250918_add_payment_fields_to_orders.down,
+    name: '20250918_add_payment_fields_to_orders',
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -252,6 +252,9 @@ export interface Order {
    * Customer contact number captured at time of order
    */
   customerNumber: string;
+  paymentMethod: 'cod' | 'bkash' | 'nagad';
+  paymentSenderNumber?: string | null;
+  paymentTransactionId?: string | null;
   items: {
     item: number | Item;
     quantity: number;
@@ -525,6 +528,9 @@ export interface OrdersSelect<T extends boolean = true> {
   customerName?: T;
   customerEmail?: T;
   customerNumber?: T;
+  paymentMethod?: T;
+  paymentSenderNumber?: T;
+  paymentTransactionId?: T;
   items?:
     | T
     | {


### PR DESCRIPTION
## Summary
- delete the previously added Cash on Delivery, bKash, and Nagad PNG assets so only the uploaded SVG logos remain referenced by checkout payment metadata

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68ca8d8c96fc832ab668957b31c89f31