### PR TITLE
feat: add configurable digital shipping policy

### DIFF
--- a/src/app/(frontend)/item/[id]/page.tsx
+++ b/src/app/(frontend)/item/[id]/page.tsx
@@ -14,6 +14,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { ShieldCheck, ShoppingCart, Truck } from 'lucide-react'
 import ReviewSection from './ReviewSection'
 import { ReviewStars } from '@/components/review-stars'
+import { normalizeDeliverySettings, DEFAULT_DELIVERY_SETTINGS } from '@/lib/delivery-settings'
 
 export const revalidate = 3600
 
@@ -35,6 +36,13 @@ export default async function ItemPage({ params }: { params: Promise<{ id: strin
   const deliveryZone = (user as any)?.deliveryZone === 'outside_dhaka' ? 'outside_dhaka' : 'inside_dhaka'
 
   const item = await getItem(id, payload)
+
+  const deliverySettingsResult = await payload
+    .find({ collection: 'delivery-settings', limit: 1 })
+    .catch(() => null)
+  const deliverySettings = normalizeDeliverySettings(
+    (deliverySettingsResult as any)?.docs?.[0] || DEFAULT_DELIVERY_SETTINGS,
+  )
 
   if (!item) {
     return notFound()
@@ -131,8 +139,8 @@ export default async function ItemPage({ params }: { params: Promise<{ id: strin
               <div className="flex items-center gap-3 p-3 border rounded-lg bg-white">
                 <Truck className="text-gray-500" />
                 <div>
-                  <p className="text-sm font-medium">Free shipping worldwide</p>
-                  <p className="text-xs text-gray-500">On all orders</p>
+                  <p className="text-sm font-medium">{deliverySettings.shippingHighlightTitle}</p>
+                  <p className="text-xs text-gray-500">{deliverySettings.shippingHighlightSubtitle}</p>
                 </div>
               </div>
               <div className="flex items-center gap-3 p-3 border rounded-lg bg-white">

--- a/src/collections/DeliverySettings.ts
+++ b/src/collections/DeliverySettings.ts
@@ -65,5 +65,30 @@ export const DeliverySettings: CollectionConfig = {
         description: 'Orders equal to or above this amount receive free delivery.',
       },
     },
+    {
+      name: 'digitalPaymentDeliveryCharge',
+      type: 'number',
+      required: true,
+      min: 0,
+      defaultValue: 20,
+      label: 'Digital payment delivery charge (BDT)',
+      admin: {
+        description: 'Applied when the order total is below the free delivery threshold.',
+      },
+    },
+    {
+      name: 'shippingHighlightTitle',
+      type: 'text',
+      required: true,
+      defaultValue: 'Free shipping on orders over 2000 taka',
+      label: 'Shipping highlight title',
+    },
+    {
+      name: 'shippingHighlightSubtitle',
+      type: 'text',
+      required: true,
+      defaultValue: 'Digital wallet payments have a flat Tk 20 delivery charge.',
+      label: 'Shipping highlight subtitle',
+    },
   ],
 }

--- a/src/lib/delivery-settings.ts
+++ b/src/lib/delivery-settings.ts
@@ -2,18 +2,30 @@ export type DeliverySettings = {
   insideDhakaCharge: number
   outsideDhakaCharge: number
   freeDeliveryThreshold: number
+  digitalPaymentDeliveryCharge: number
+  shippingHighlightTitle: string
+  shippingHighlightSubtitle: string
 }
 
 export const DEFAULT_DELIVERY_SETTINGS: DeliverySettings = {
   insideDhakaCharge: 80,
   outsideDhakaCharge: 120,
   freeDeliveryThreshold: 2000,
+  digitalPaymentDeliveryCharge: 20,
+  shippingHighlightTitle: 'Free shipping on orders over 2000 taka',
+  shippingHighlightSubtitle: 'Digital wallet payments have a flat Tk 20 delivery charge.',
 }
 
 const toPositiveNumber = (value: unknown, fallback: number) => {
   const parsed = Number(value)
   if (!Number.isFinite(parsed) || parsed < 0) return fallback
   return parsed
+}
+
+const toStringOrFallback = (value: unknown, fallback: string) => {
+  if (typeof value !== 'string') return fallback
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : fallback
 }
 
 export const normalizeDeliverySettings = (raw: any): DeliverySettings => {
@@ -25,5 +37,17 @@ export const normalizeDeliverySettings = (raw: any): DeliverySettings => {
     insideDhakaCharge: toPositiveNumber((raw as any).insideDhakaCharge, DEFAULT_DELIVERY_SETTINGS.insideDhakaCharge),
     outsideDhakaCharge: toPositiveNumber((raw as any).outsideDhakaCharge, DEFAULT_DELIVERY_SETTINGS.outsideDhakaCharge),
     freeDeliveryThreshold: toPositiveNumber((raw as any).freeDeliveryThreshold, DEFAULT_DELIVERY_SETTINGS.freeDeliveryThreshold),
+    digitalPaymentDeliveryCharge: toPositiveNumber(
+      (raw as any).digitalPaymentDeliveryCharge,
+      DEFAULT_DELIVERY_SETTINGS.digitalPaymentDeliveryCharge,
+    ),
+    shippingHighlightTitle: toStringOrFallback(
+      (raw as any).shippingHighlightTitle,
+      DEFAULT_DELIVERY_SETTINGS.shippingHighlightTitle,
+    ),
+    shippingHighlightSubtitle: toStringOrFallback(
+      (raw as any).shippingHighlightSubtitle,
+      DEFAULT_DELIVERY_SETTINGS.shippingHighlightSubtitle,
+    ),
   }
 }

--- a/src/lib/payment-options.ts
+++ b/src/lib/payment-options.ts
@@ -15,9 +15,15 @@ export interface PaymentOption {
 
 export const DIGITAL_PAYMENT_ACCOUNT_NUMBER = '01739-416661'
 
-export const DIGITAL_PAYMENT_INSTRUCTIONS: Partial<Record<PaymentMethod, string>> = {
-  bkash: `Send your payment to our bKash number ${DIGITAL_PAYMENT_ACCOUNT_NUMBER} using "Send Money". After completing the transfer, include your centre number if prompted and provide the sender wallet number and transaction ID in the boxes below so we can verify your payment.`,
-  nagad: `Send your payment to our Nagad number ${DIGITAL_PAYMENT_ACCOUNT_NUMBER} using "Send Money". After completing the transfer, include your centre number if prompted and provide the sender wallet number and transaction ID in the boxes below so we can verify your payment.`,
+export const DIGITAL_PAYMENT_INSTRUCTIONS: Partial<Record<PaymentMethod, string[]>> = {
+  bkash: [
+    `Send your payment to our bKash number ${DIGITAL_PAYMENT_ACCOUNT_NUMBER} using "Send Money".`,
+    'After completing the transfer, provide the sender wallet number and transaction ID in the boxes below so we can verify your payment.',
+  ],
+  nagad: [
+    `Send your payment to our Nagad number ${DIGITAL_PAYMENT_ACCOUNT_NUMBER} using "Send Money".`,
+    'After completing the transfer, provide the sender wallet number and transaction ID in the boxes below so we can verify your payment.',
+  ],
 }
 
 export const DIGITAL_PAYMENT_METHODS: PaymentMethod[] = ['bkash', 'nagad']

--- a/src/migrations/20250919_update_delivery_settings_with_highlight.ts
+++ b/src/migrations/20250919_update_delivery_settings_with_highlight.ts
@@ -3,21 +3,26 @@ import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-vercel-postg
 const DEFAULT_TITLE = 'Free shipping on orders over 2000 taka'
 const DEFAULT_SUBTITLE = 'Digital wallet payments have a flat Tk 20 delivery charge.'
 
+const escapeLiteral = (value: string): string => value.replace(/'/g, "''")
+
+const DEFAULT_TITLE_LITERAL = `'${escapeLiteral(DEFAULT_TITLE)}'`
+const DEFAULT_SUBTITLE_LITERAL = `'${escapeLiteral(DEFAULT_SUBTITLE)}'`
+
 export async function up({ db }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`
     ALTER TABLE "delivery_settings"
       ADD COLUMN IF NOT EXISTS "digital_payment_delivery_charge" numeric DEFAULT 20 NOT NULL
   `)
 
-  await db.execute(sql`
+  await db.execute(sql.raw(`
     ALTER TABLE "delivery_settings"
-      ADD COLUMN IF NOT EXISTS "shipping_highlight_title" varchar DEFAULT ${DEFAULT_TITLE} NOT NULL
-  `)
+      ADD COLUMN IF NOT EXISTS "shipping_highlight_title" varchar DEFAULT ${DEFAULT_TITLE_LITERAL} NOT NULL
+  `))
 
-  await db.execute(sql`
+  await db.execute(sql.raw(`
     ALTER TABLE "delivery_settings"
-      ADD COLUMN IF NOT EXISTS "shipping_highlight_subtitle" varchar DEFAULT ${DEFAULT_SUBTITLE} NOT NULL
-  `)
+      ADD COLUMN IF NOT EXISTS "shipping_highlight_subtitle" varchar DEFAULT ${DEFAULT_SUBTITLE_LITERAL} NOT NULL
+  `))
 
   await db.execute(sql`
     UPDATE "delivery_settings"

--- a/src/migrations/20250919_update_delivery_settings_with_highlight.ts
+++ b/src/migrations/20250919_update_delivery_settings_with_highlight.ts
@@ -6,12 +6,20 @@ const DEFAULT_SUBTITLE = 'Digital wallet payments have a flat Tk 20 delivery cha
 export async function up({ db }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`
     ALTER TABLE "delivery_settings"
-      ADD COLUMN IF NOT EXISTS "digital_payment_delivery_charge" numeric DEFAULT 20 NOT NULL;
-    ALTER TABLE "delivery_settings"
-      ADD COLUMN IF NOT EXISTS "shipping_highlight_title" varchar DEFAULT ${DEFAULT_TITLE} NOT NULL;
-    ALTER TABLE "delivery_settings"
-      ADD COLUMN IF NOT EXISTS "shipping_highlight_subtitle" varchar DEFAULT ${DEFAULT_SUBTITLE} NOT NULL;
+      ADD COLUMN IF NOT EXISTS "digital_payment_delivery_charge" numeric DEFAULT 20 NOT NULL
+  `)
 
+  await db.execute(sql`
+    ALTER TABLE "delivery_settings"
+      ADD COLUMN IF NOT EXISTS "shipping_highlight_title" varchar DEFAULT ${DEFAULT_TITLE} NOT NULL
+  `)
+
+  await db.execute(sql`
+    ALTER TABLE "delivery_settings"
+      ADD COLUMN IF NOT EXISTS "shipping_highlight_subtitle" varchar DEFAULT ${DEFAULT_SUBTITLE} NOT NULL
+  `)
+
+  await db.execute(sql`
     UPDATE "delivery_settings"
     SET
       "digital_payment_delivery_charge" = COALESCE("digital_payment_delivery_charge", 20),
@@ -22,7 +30,7 @@ export async function up({ db }: MigrateUpArgs): Promise<void> {
       "shipping_highlight_subtitle" = CASE
         WHEN TRIM(COALESCE("shipping_highlight_subtitle", '')) = '' THEN ${DEFAULT_SUBTITLE}
         ELSE "shipping_highlight_subtitle"
-      END;
+      END
   `)
 }
 

--- a/src/migrations/20250919_update_delivery_settings_with_highlight.ts
+++ b/src/migrations/20250919_update_delivery_settings_with_highlight.ts
@@ -1,0 +1,36 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-vercel-postgres'
+
+const DEFAULT_TITLE = 'Free shipping on orders over 2000 taka'
+const DEFAULT_SUBTITLE = 'Digital wallet payments have a flat Tk 20 delivery charge.'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "delivery_settings"
+      ADD COLUMN IF NOT EXISTS "digital_payment_delivery_charge" numeric DEFAULT 20 NOT NULL;
+    ALTER TABLE "delivery_settings"
+      ADD COLUMN IF NOT EXISTS "shipping_highlight_title" varchar DEFAULT ${DEFAULT_TITLE} NOT NULL;
+    ALTER TABLE "delivery_settings"
+      ADD COLUMN IF NOT EXISTS "shipping_highlight_subtitle" varchar DEFAULT ${DEFAULT_SUBTITLE} NOT NULL;
+
+    UPDATE "delivery_settings"
+    SET
+      "digital_payment_delivery_charge" = COALESCE("digital_payment_delivery_charge", 20),
+      "shipping_highlight_title" = CASE
+        WHEN TRIM(COALESCE("shipping_highlight_title", '')) = '' THEN ${DEFAULT_TITLE}
+        ELSE "shipping_highlight_title"
+      END,
+      "shipping_highlight_subtitle" = CASE
+        WHEN TRIM(COALESCE("shipping_highlight_subtitle", '')) = '' THEN ${DEFAULT_SUBTITLE}
+        ELSE "shipping_highlight_subtitle"
+      END;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "delivery_settings"
+      DROP COLUMN IF EXISTS "digital_payment_delivery_charge",
+      DROP COLUMN IF EXISTS "shipping_highlight_title",
+      DROP COLUMN IF EXISTS "shipping_highlight_subtitle";
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -16,6 +16,7 @@ import * as migration_20250916_add_short_description_to_items from './20250916_a
 import * as migration_20250917_add_delivery_settings from './20250917_add_delivery_settings';
 import * as migration_20250917_add_delivery_settings_lock_rel from './20250917_add_delivery_settings_lock_rel';
 import * as migration_20250918_add_payment_fields_to_orders from './20250918_add_payment_fields_to_orders';
+import * as migration_20250919_update_delivery_settings_with_highlight from './20250919_update_delivery_settings_with_highlight';
 
 export const migrations = [
   {
@@ -107,5 +108,10 @@ export const migrations = [
     up: migration_20250918_add_payment_fields_to_orders.up,
     down: migration_20250918_add_payment_fields_to_orders.down,
     name: '20250918_add_payment_fields_to_orders',
+  },
+  {
+    up: migration_20250919_update_delivery_settings_with_highlight.up,
+    down: migration_20250919_update_delivery_settings_with_highlight.down,
+    name: '20250919_update_delivery_settings_with_highlight',
   },
 ];


### PR DESCRIPTION
## Summary
- add editable digital payment delivery charge and shipping highlight fields to delivery settings via a new migration
- update checkout and order flows to apply the digital payment delivery fee, surface bullet-point wallet instructions, and respect the configurable messaging
- fetch delivery settings on the item detail page to show the updated shipping highlight copy

## Testing
- `pnpm lint`
- `PAYLOAD_SECRET=test pnpm payload migrate` *(fails: database connection unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cb4eb77db0832a98f8e9a72afc4275