### PR TITLE
Increase mobile header opacity

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -31,7 +31,7 @@ export function SiteHeader({
     return (
       <>
         <header
-          className={`fixed inset-x-0 top-0 z-50 w-full border-b border-gray-200/60 bg-white/80 backdrop-blur-none sm:backdrop-blur-2xl ${className}`}
+          className={`fixed inset-x-0 top-0 z-50 w-full border-b border-gray-200/60 bg-white/95 sm:bg-white/80 backdrop-blur-none sm:backdrop-blur-2xl ${className}`}
         >
           <div className="container mx-auto flex h-20 items-center justify-between px-4 sm:px-6 lg:px-8">
             <Link href="/" className="flex items-center gap-3 group">


### PR DESCRIPTION
## Summary
- increase the mobile header background opacity while keeping the existing desktop styling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cb5760a5fc832a9876f0d9f04bd343