### PR TITLE
Prevent cart quantity doubling on reload

### DIFF
--- a/src/lib/cart-context.tsx
+++ b/src/lib/cart-context.tsx
@@ -132,7 +132,7 @@ const cartReducer = (state: CartState, action: CartAction): CartState => {
           mergedMap.set(incoming.id, {
             ...existing,
             ...incoming,
-            quantity: existing.quantity + incoming.quantity,
+            quantity: Math.max(existing.quantity, incoming.quantity),
           })
         } else {
           mergedMap.set(incoming.id, incoming)


### PR DESCRIPTION
## Summary
- stop merging cart quantities by summing local and server counts; prefer the higher of the two instead
- ensure reloading and server sync no longer doubles item quantities

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cb5bc31704832ab3b59f6fa7eb21a0