### PR TITLE
Implement cart merge and persistence between guest and user

### DIFF
--- a/src/app/(frontend)/login/page.tsx
+++ b/src/app/(frontend)/login/page.tsx
@@ -37,6 +37,8 @@ function LoginForm() {
         return
       }
 
+      const sessionIdRaw = isRecord(parsed) && typeof parsed.sessionId === 'string' ? parsed.sessionId : null
+
       const itemsPayload = itemsRaw
         .map((item) => {
           if (!isRecord(item)) return null
@@ -57,11 +59,16 @@ function LoginForm() {
         return
       }
 
+      const bodyPayload: Record<string, unknown> = { items: itemsPayload }
+      if (sessionIdRaw) {
+        bodyPayload.sessionId = sessionIdRaw
+      }
+
       const response = await fetch('/api/cart/merge', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ items: itemsPayload }),
+        body: JSON.stringify(bodyPayload),
       })
 
       if (!response.ok) {

--- a/src/app/api/cart/cart-helpers.ts
+++ b/src/app/api/cart/cart-helpers.ts
@@ -1,0 +1,265 @@
+import type { Payload } from 'payload'
+
+export type CartLine = { item: number; quantity: number }
+export type IncomingCartItem = { id: string | number; quantity: number }
+export type SerializedCartItem = {
+  id: string
+  name: string
+  price: number
+  quantity: number
+  category: string
+  image?: {
+    url: string
+    alt?: string
+  }
+}
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+export const toItemId = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
+    return Number(value.trim())
+  }
+  return null
+}
+
+export const resolveUserId = (user: unknown): number | null => {
+  if (!isRecord(user)) return null
+  const idRaw = user.id
+  if (typeof idRaw === 'number' && Number.isFinite(idRaw)) return idRaw
+  return toItemId(idRaw)
+}
+
+const pickCategoryName = (value: unknown): string => {
+  if (typeof value === 'string') return value
+  if (isRecord(value) && typeof value.name === 'string') return value.name
+  return ''
+}
+
+const pickImage = (itemDoc: Record<string, unknown>): SerializedCartItem['image'] => {
+  const imageValue = itemDoc.image
+  if (isRecord(imageValue) && typeof imageValue.url === 'string') {
+    return {
+      url: imageValue.url,
+      alt: typeof imageValue.alt === 'string' ? imageValue.alt : undefined,
+    }
+  }
+  if (typeof itemDoc.imageUrl === 'string') {
+    return { url: itemDoc.imageUrl }
+  }
+  return undefined
+}
+
+const clampQuantityForItem = (itemDoc: Record<string, unknown>, requested: number): number => {
+  if (!Number.isFinite(requested) || requested <= 0) return 0
+  const limits: number[] = []
+  const candidateKeys = [
+    'maxPerOrder',
+    'maxOrderQuantity',
+    'maxQuantity',
+    'maxPerCustomer',
+    'maxPurchaseQuantity',
+    'inventoryPerCustomer',
+  ]
+  for (const key of candidateKeys) {
+    const raw = (itemDoc as Record<string, unknown>)[key]
+    const value = Number(raw)
+    if (Number.isFinite(value) && value > 0) {
+      limits.push(Math.floor(value))
+    }
+  }
+  if (typeof itemDoc.available === 'boolean' && itemDoc.available === false) {
+    return 0
+  }
+  if (!limits.length) return Math.max(Math.floor(requested), 0)
+  return Math.max(Math.min(Math.floor(requested), Math.min(...limits)), 0)
+}
+
+export const normalizeIncomingItems = (value: unknown): IncomingCartItem[] => {
+  if (!Array.isArray(value)) return []
+  const items: IncomingCartItem[] = []
+  for (const raw of value) {
+    if (!isRecord(raw)) continue
+    const idCandidate = raw.id
+    const quantityRaw = Number(raw.quantity)
+    const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0 ? Math.floor(quantityRaw) : 0
+    if (quantity <= 0) continue
+    if (typeof idCandidate === 'string' || typeof idCandidate === 'number') {
+      items.push({ id: idCandidate, quantity })
+    }
+  }
+  return items
+}
+
+export const buildQuantityMapFromIncoming = (items: IncomingCartItem[]): Map<number, number> => {
+  const map = new Map<number, number>()
+  for (const item of items) {
+    const numericId = toItemId(item.id)
+    if (numericId === null) continue
+    const quantity = Math.max(0, Math.floor(item.quantity))
+    if (quantity <= 0) continue
+    map.set(numericId, (map.get(numericId) ?? 0) + quantity)
+  }
+  return map
+}
+
+export const extractCartQuantities = (doc: unknown): Map<number, number> => {
+  const map = new Map<number, number>()
+  if (!isRecord(doc)) return map
+  const items = doc.items
+  if (!Array.isArray(items)) return map
+  for (const entry of items) {
+    if (!isRecord(entry)) continue
+    const itemId = toItemId(entry.item)
+    const quantityRaw = Number(entry.quantity)
+    const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0 ? Math.floor(quantityRaw) : 0
+    if (itemId === null || quantity <= 0) continue
+    map.set(itemId, (map.get(itemId) ?? 0) + quantity)
+  }
+  return map
+}
+
+export const resolveCartPayload = async (
+  payload: Payload,
+  quantityMap: Map<number, number>,
+): Promise<{
+  lines: CartLine[]
+  serialized: SerializedCartItem[]
+  total: number
+  snapshot: Record<string, number>
+}> => {
+  if (quantityMap.size === 0) {
+    return { lines: [], serialized: [], total: 0, snapshot: {} }
+  }
+
+  const ids = Array.from(quantityMap.keys())
+  const itemsResult = await payload.find({
+    collection: 'items',
+    where: {
+      id: { in: ids },
+    },
+    depth: 2,
+    limit: ids.length,
+  })
+
+  const itemsMap = new Map<number, Record<string, unknown>>()
+  for (const item of itemsResult.docs) {
+    if (!isRecord(item)) continue
+    const numericId = toItemId(item.id)
+    if (numericId === null) continue
+    itemsMap.set(numericId, item)
+  }
+
+  const lines: CartLine[] = []
+  const serialized: SerializedCartItem[] = []
+  const snapshot: Record<string, number> = {}
+  let total = 0
+
+  for (const [itemId, requestedQuantity] of quantityMap.entries()) {
+    const itemDoc = itemsMap.get(itemId)
+    if (!itemDoc) continue
+    const quantity = clampQuantityForItem(itemDoc, requestedQuantity)
+    if (quantity <= 0) continue
+
+    const priceRaw = Number(itemDoc.price)
+    const price = Number.isFinite(priceRaw) && priceRaw >= 0 ? priceRaw : 0
+    total += price * quantity
+
+    lines.push({ item: itemId, quantity })
+    const idRaw = itemDoc.id
+    const id = typeof idRaw === 'string' ? idRaw : String(idRaw)
+
+    serialized.push({
+      id,
+      name: typeof itemDoc.name === 'string' ? itemDoc.name : String(itemDoc.name ?? ''),
+      price,
+      quantity,
+      category: pickCategoryName(itemDoc.category),
+      image: pickImage(itemDoc),
+    })
+
+    snapshot[id] = quantity
+  }
+
+  return { lines, serialized, total, snapshot }
+}
+
+export const getDocId = (doc: unknown): number | string | null => {
+  if (!isRecord(doc)) return null
+  const { id } = doc
+  if (typeof id === 'number' && Number.isFinite(id)) return id
+  if (typeof id === 'string' && id.length > 0) return id
+  return null
+}
+
+export const getSessionIdFromDoc = (doc: unknown): string | null => {
+  if (!isRecord(doc)) return null
+  const sid = doc.sessionId
+  if (typeof sid === 'string' && sid.trim().length > 0) return sid
+  return null
+}
+
+export const generateSessionId = (): string => {
+  try {
+    if (typeof globalThis.crypto?.randomUUID === 'function') {
+      return globalThis.crypto.randomUUID()
+    }
+  } catch {}
+  return Math.random().toString(36).slice(2)
+}
+
+export const buildSnapshotMap = (items: SerializedCartItem[]): Record<string, number> => {
+  const snapshot: Record<string, number> = {}
+  for (const item of items) {
+    if (typeof item.id === 'string' && typeof item.quantity === 'number') {
+      snapshot[item.id] = item.quantity
+    }
+  }
+  return snapshot
+}
+
+export const findActiveCartForUser = async (
+  payload: Payload,
+  userId: number,
+): Promise<Record<string, unknown> | null> => {
+  const query = await payload.find({
+    collection: 'abandoned-carts',
+    overrideAccess: true,
+    limit: 1,
+    depth: 0,
+    sort: '-updatedAt',
+    where: {
+      and: [
+        { user: { equals: userId } },
+        { status: { not_equals: 'recovered' } },
+      ],
+    },
+  })
+
+  const doc = query?.docs?.[0]
+  return isRecord(doc) ? doc : null
+}
+
+export const findCartBySession = async (
+  payload: Payload,
+  sessionId: string,
+): Promise<Record<string, unknown> | null> => {
+  const query = await payload.find({
+    collection: 'abandoned-carts',
+    overrideAccess: true,
+    limit: 1,
+    depth: 0,
+    sort: '-updatedAt',
+    where: {
+      and: [
+        { sessionId: { equals: sessionId } },
+        { status: { not_equals: 'recovered' } },
+      ],
+    },
+  })
+
+  const doc = query?.docs?.[0]
+  return isRecord(doc) ? doc : null
+}

--- a/src/app/api/cart/merge/route.ts
+++ b/src/app/api/cart/merge/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 
+import type { AbandonedCart } from '@/payload-types'
+
 import config from '@/payload.config'
 import {
   buildQuantityMapFromIncoming,
@@ -92,13 +94,21 @@ export async function POST(request: NextRequest) {
       getSessionIdFromDoc(userCart) ?? getSessionIdFromDoc(sessionCart) ?? sessionIdCandidate
     const sessionId = sourceSessionId ?? generateSessionId()
 
-    const data: Record<string, unknown> = {
+    const nowIso = new Date().toISOString()
+
+    const data: Omit<AbandonedCart, 'id' | 'createdAt' | 'updatedAt'> = {
       sessionId,
       user: userId,
       items: resolved.lines,
       cartTotal: resolved.total,
       status: 'active',
-      lastActivityAt: new Date().toISOString(),
+      lastActivityAt: nowIso,
+      customerName: null,
+      customerEmail: null,
+      customerNumber: null,
+      recoveredOrder: null,
+      recoveryEmailSentAt: null,
+      notes: null,
     }
 
     if (targetCartId !== null) {

--- a/src/app/api/cart/merge/route.ts
+++ b/src/app/api/cart/merge/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+
+import config from '@/payload.config'
+import {
+  buildQuantityMapFromIncoming,
+  extractCartQuantities,
+  findActiveCartForUser,
+  findCartBySession,
+  generateSessionId,
+  getDocId,
+  getSessionIdFromDoc,
+  normalizeIncomingItems,
+  resolveCartPayload,
+  resolveUserId,
+} from '../cart-helpers'
+
+const mergeQuantityMaps = (
+  base: Map<number, number>,
+  additions: Map<number, number>,
+): Map<number, number> => {
+  const next = new Map(base)
+  for (const [id, quantity] of additions.entries()) {
+    const existing = next.get(id) ?? 0
+    next.set(id, existing + quantity)
+  }
+  return next
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await getPayload({ config: await config })
+    const { user } = await payload.auth({ headers: request.headers })
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const userId = resolveUserId(user)
+    if (typeof userId !== 'number') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+    const itemsInput = body && typeof body === 'object' ? (body as any).items : null
+    const incomingItems = normalizeIncomingItems(itemsInput)
+    const incomingMap = buildQuantityMapFromIncoming(incomingItems)
+
+    const cookieSession = request.cookies.get('dyad_cart_sid')?.value
+    const payloadSession =
+      typeof body === 'object' && body && typeof (body as any).sessionId === 'string'
+        ? (body as any).sessionId
+        : undefined
+
+    const userCart = await findActiveCartForUser(payload, userId)
+    const sessionIdCandidate = payloadSession || cookieSession
+    const sessionCart = sessionIdCandidate
+      ? await findCartBySession(payload, sessionIdCandidate)
+      : null
+
+    const quantityMap = new Map<number, number>()
+
+    if (userCart) {
+      const existing = extractCartQuantities(userCart)
+      for (const [id, quantity] of existing.entries()) {
+        quantityMap.set(id, (quantityMap.get(id) ?? 0) + quantity)
+      }
+    }
+
+    if (sessionCart && getDocId(sessionCart) !== getDocId(userCart)) {
+      const existing = extractCartQuantities(sessionCart)
+      for (const [id, quantity] of existing.entries()) {
+        quantityMap.set(id, (quantityMap.get(id) ?? 0) + quantity)
+      }
+    }
+
+    const mergedMap = mergeQuantityMaps(quantityMap, incomingMap)
+    const resolved = await resolveCartPayload(payload, mergedMap)
+
+    const targetCartId = getDocId(userCart) ?? getDocId(sessionCart)
+    const sourceSessionId =
+      getSessionIdFromDoc(userCart) ?? getSessionIdFromDoc(sessionCart) ?? sessionIdCandidate
+    const sessionId = sourceSessionId ?? generateSessionId()
+
+    const data: Record<string, unknown> = {
+      sessionId,
+      user: userId,
+      items: resolved.lines,
+      cartTotal: resolved.total,
+      status: 'active',
+      lastActivityAt: new Date().toISOString(),
+    }
+
+    if (targetCartId !== null) {
+      await payload.update({ collection: 'abandoned-carts', id: targetCartId as any, data })
+    } else {
+      await payload.create({ collection: 'abandoned-carts', data })
+    }
+
+    if (userCart && sessionCart && getDocId(sessionCart) !== getDocId(userCart)) {
+      const orphanId = getDocId(sessionCart)
+      if (orphanId !== null) {
+        try {
+          await payload.delete({ collection: 'abandoned-carts', id: orphanId as any })
+        } catch (error) {
+          console.warn('Failed to remove guest cart after merge:', error)
+        }
+      }
+    }
+
+    const response = NextResponse.json({
+      success: true,
+      items: resolved.serialized,
+      total: resolved.total,
+      snapshot: resolved.snapshot,
+    })
+
+    if (sessionId) {
+      response.cookies.set('dyad_cart_sid', String(sessionId), {
+        path: '/',
+        httpOnly: false,
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 30,
+      })
+    }
+
+    return response
+  } catch (error) {
+    console.error('Failed to merge carts:', error)
+    return NextResponse.json({ error: 'Failed to merge carts' }, { status: 500 })
+  }
+}

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 
+import type { AbandonedCart } from '@/payload-types'
+
 import config from '@/payload.config'
 import {
   buildQuantityMapFromIncoming,
@@ -83,13 +85,21 @@ export async function POST(request: NextRequest) {
     const cookieSession = request.cookies.get('dyad_cart_sid')?.value
     const sessionId = existingSession ?? payloadSessionId ?? cookieSession ?? generateSessionId()
 
-    const data: Record<string, unknown> = {
+    const nowIso = new Date().toISOString()
+
+    const data: Omit<AbandonedCart, 'id' | 'createdAt' | 'updatedAt'> = {
       sessionId,
       user: userId,
       items: resolved.lines,
       cartTotal: resolved.total,
       status: 'active',
-      lastActivityAt: new Date().toISOString(),
+      lastActivityAt: nowIso,
+      customerName: null,
+      customerEmail: null,
+      customerNumber: null,
+      recoveredOrder: null,
+      recoveryEmailSentAt: null,
+      notes: null,
     }
 
     const cartId = getDocId(cartDoc)

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -2,64 +2,18 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 
 import config from '@/payload.config'
-
-type CartLine = {
-  item: number
-  quantity: number
-}
-
-type ItemRecord = Record<string, unknown>
-type SerializedCartItem = {
-  id: string
-  name: string
-  price: number
-  quantity: number
-  category: string
-  image?: {
-    url: string
-    alt?: string
-  }
-}
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null
-
-const toCartLine = (value: unknown): CartLine | null => {
-  if (!isRecord(value)) return null
-  const itemId = value.item
-  if (typeof itemId !== 'number') return null
-  const quantityRaw = Number(value.quantity)
-  const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0 ? Math.floor(quantityRaw) : 1
-  return { item: itemId, quantity }
-}
-
-const toItemId = (value: unknown): number | null => {
-  if (typeof value === 'number' && Number.isFinite(value)) return value
-  if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
-    return Number(value.trim())
-  }
-  return null
-}
-
-const pickCategoryName = (value: unknown): string => {
-  if (typeof value === 'string') return value
-  if (isRecord(value) && typeof value.name === 'string') return value.name
-  return ''
-}
-
-const pickImage = (itemDoc: ItemRecord): SerializedCartItem['image'] => {
-  const imageValue = itemDoc.image
-  if (isRecord(imageValue) && typeof imageValue.url === 'string') {
-    return {
-      url: imageValue.url,
-      alt: typeof imageValue.alt === 'string' ? imageValue.alt : undefined,
-    }
-  }
-  if (typeof itemDoc.imageUrl === 'string') {
-    return { url: itemDoc.imageUrl }
-  }
-  return undefined
-}
+import {
+  buildQuantityMapFromIncoming,
+  extractCartQuantities,
+  findActiveCartForUser,
+  generateSessionId,
+  getDocId,
+  getSessionIdFromDoc,
+  isRecord,
+  normalizeIncomingItems,
+  resolveCartPayload,
+  resolveUserId,
+} from './cart-helpers'
 
 export async function GET(request: NextRequest) {
   try {
@@ -70,113 +24,28 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const userIdRaw = user.id
-    const userId = typeof userIdRaw === 'number' ? userIdRaw : toItemId(userIdRaw)
+    const userId = resolveUserId(user)
     if (typeof userId !== 'number') {
       return NextResponse.json({ items: [], total: 0 })
     }
 
-    const cartQuery = await payload.find({
-      collection: 'abandoned-carts',
-      overrideAccess: true,
-      limit: 1,
-      depth: 0,
-      sort: '-updatedAt',
-      where: {
-        and: [
-          { user: { equals: userId } },
-          { status: { not_equals: 'recovered' } },
-        ],
-      },
-    })
+    const cartDoc = await findActiveCartForUser(payload, userId)
 
-    const cartDoc = cartQuery?.docs?.[0]
-
-    if (!isRecord(cartDoc)) {
+    if (!cartDoc) {
       return NextResponse.json({ items: [], total: 0 })
     }
 
-    const cartRecord = cartDoc as Record<string, unknown>
+    const quantityMap = extractCartQuantities(cartDoc)
+    const { serialized, total: computedTotal } = await resolveCartPayload(payload, quantityMap)
 
-    const cartUserRaw = cartRecord.user
-    const cartUserId = typeof cartUserRaw === 'number' ? cartUserRaw : toItemId(cartUserRaw)
-    if (cartUserId !== userId) {
-      return NextResponse.json({ items: [], total: 0 })
-    }
-
-    const lines: CartLine[] = Array.isArray(cartRecord.items)
-      ? cartRecord.items
-          .map((line) => toCartLine(line))
-          .filter((line): line is CartLine => line !== null)
-      : []
-    const itemIds = lines.map((line) => line.item)
-
-    const itemsMap = new Map<number, ItemRecord>()
-    if (itemIds.length > 0) {
-      const uniqueIds = Array.from(new Set(itemIds))
-      const itemsResult = await payload.find({
-        collection: 'items',
-        where: {
-          id: { in: uniqueIds },
-        },
-        depth: 2,
-        limit: uniqueIds.length,
-      })
-
-      for (const item of itemsResult.docs) {
-        if (!isRecord(item)) continue
-        const numericId = toItemId(item.id)
-        if (numericId !== null) {
-          itemsMap.set(numericId, item)
-        }
-      }
-    }
-
-    const merged = new Map<string, SerializedCartItem>()
-    for (const line of lines) {
-      const itemDoc = itemsMap.get(line.item)
-      if (!itemDoc) continue
-
-      const idRaw = itemDoc.id
-      const id = typeof idRaw === 'string' ? idRaw : String(idRaw)
-      const quantity = line.quantity
-      const priceRaw = Number(itemDoc.price)
-      const price = Number.isFinite(priceRaw) && priceRaw >= 0 ? priceRaw : 0
-
-      const category = pickCategoryName(itemDoc.category)
-      const image = pickImage(itemDoc)
-
-      const existing = merged.get(id)
-      if (existing) {
-        merged.set(id, {
-          ...existing,
-          quantity: existing.quantity + quantity,
-        })
-      } else {
-        merged.set(id, {
-          id,
-          name: typeof itemDoc.name === 'string' ? itemDoc.name : String(itemDoc.name ?? ''),
-          price,
-          quantity,
-          category,
-          image,
-        })
-      }
-    }
-
-    const items = Array.from(merged.values())
-
-    const totalRaw = typeof cartRecord.cartTotal === 'number' ? cartRecord.cartTotal : undefined
-    const total =
-      typeof totalRaw === 'number'
-        ? totalRaw
-        : items.reduce((sum, item) => sum + item.price * item.quantity, 0)
+    const totalRaw = isRecord(cartDoc) && typeof cartDoc.cartTotal === 'number' ? cartDoc.cartTotal : undefined
+    const total = typeof totalRaw === 'number' ? totalRaw : computedTotal
 
     return NextResponse.json({
-      items,
+      items: serialized,
       total,
-      sourceUpdatedAt: typeof cartRecord.updatedAt === 'string' ? cartRecord.updatedAt : null,
-      sessionId: typeof cartRecord.sessionId === 'string' ? cartRecord.sessionId : null,
+      sourceUpdatedAt: isRecord(cartDoc) && typeof cartDoc.updatedAt === 'string' ? cartDoc.updatedAt : null,
+      sessionId: getSessionIdFromDoc(cartDoc),
     })
   } catch (error) {
     console.error('Failed to load persisted cart:', error)
@@ -184,3 +53,72 @@ export async function GET(request: NextRequest) {
   }
 }
 
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await getPayload({ config: await config })
+    const { user } = await payload.auth({ headers: request.headers })
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const userId = resolveUserId(user)
+    if (typeof userId !== 'number') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+    const itemsInput = isRecord(body) ? body.items : null
+    const incomingItems = normalizeIncomingItems(itemsInput)
+    const quantityMap = buildQuantityMapFromIncoming(incomingItems)
+
+    const cartDoc = await findActiveCartForUser(payload, userId)
+    const resolved = await resolveCartPayload(payload, quantityMap)
+
+    const existingSession = getSessionIdFromDoc(cartDoc)
+    const cookieSession = request.cookies.get('dyad_cart_sid')?.value
+    const sessionId = existingSession ?? cookieSession ?? generateSessionId()
+
+    const data: Record<string, unknown> = {
+      sessionId,
+      user: userId,
+      items: resolved.lines,
+      cartTotal: resolved.total,
+      status: 'active',
+      lastActivityAt: new Date().toISOString(),
+    }
+
+    const cartId = getDocId(cartDoc)
+
+    if (cartId !== null) {
+      await payload.update({
+        collection: 'abandoned-carts',
+        id: cartId as any,
+        data,
+      })
+    } else {
+      await payload.create({ collection: 'abandoned-carts', data })
+    }
+
+    const response = NextResponse.json({
+      success: true,
+      items: resolved.serialized,
+      total: resolved.total,
+      snapshot: resolved.snapshot,
+    })
+
+    if (sessionId) {
+      response.cookies.set('dyad_cart_sid', String(sessionId), {
+        path: '/',
+        httpOnly: false,
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 30,
+      })
+    }
+
+    return response
+  } catch (error) {
+    console.error('Failed to persist cart:', error)
+    return NextResponse.json({ error: 'Failed to persist cart' }, { status: 500 })
+  }
+}

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -69,6 +69,10 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json().catch(() => null)
     const itemsInput = isRecord(body) ? body.items : null
+    const payloadSessionId =
+      isRecord(body) && typeof body.sessionId === 'string' && body.sessionId.trim().length > 0
+        ? body.sessionId.trim()
+        : undefined
     const incomingItems = normalizeIncomingItems(itemsInput)
     const quantityMap = buildQuantityMapFromIncoming(incomingItems)
 
@@ -77,7 +81,7 @@ export async function POST(request: NextRequest) {
 
     const existingSession = getSessionIdFromDoc(cartDoc)
     const cookieSession = request.cookies.get('dyad_cart_sid')?.value
-    const sessionId = existingSession ?? cookieSession ?? generateSessionId()
+    const sessionId = existingSession ?? payloadSessionId ?? cookieSession ?? generateSessionId()
 
     const data: Record<string, unknown> = {
       sessionId,
@@ -105,6 +109,7 @@ export async function POST(request: NextRequest) {
       items: resolved.serialized,
       total: resolved.total,
       snapshot: resolved.snapshot,
+      sessionId,
     })
 
     if (sessionId) {

--- a/src/lib/cart-context.tsx
+++ b/src/lib/cart-context.tsx
@@ -162,6 +162,8 @@ export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [hasLoadedLocalCart, setHasLoadedLocalCart] = useState(false)
   const hasSyncedServerCartRef = useRef(false)
   const serverSnapshotRef = useRef<Map<string, number>>(new Map())
+  const isAuthenticatedRef = useRef(false)
+  const persistTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Load cart from localStorage on mount
   useEffect(() => {
@@ -216,11 +218,17 @@ export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children
     hasSyncedServerCartRef.current = true
     try {
       const response = await fetch('/api/cart', { credentials: 'include' })
+      if (response.status === 401) {
+        isAuthenticatedRef.current = false
+        hasSyncedServerCartRef.current = false
+        return
+      }
       if (!response.ok) {
         // Allow retry on future attempts
         hasSyncedServerCartRef.current = false
         return
       }
+      isAuthenticatedRef.current = true
       const data = (await response.json().catch(() => null)) as unknown
       if (!isRecord(data) || !Array.isArray(data.items)) {
         serverSnapshotRef.current = new Map()
@@ -244,13 +252,18 @@ export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children
         const existing = existingMap.get(incoming.id)
         const previousServerQuantity = previousSnapshot.get(incoming.id) ?? 0
         const existingQuantity = existing?.quantity ?? 0
-        const guestContribution = Math.max(existingQuantity - previousServerQuantity, 0)
-        const mergedQuantity = incoming.quantity + guestContribution
-        mergedMap.set(incoming.id, {
-          ...(existing ?? incoming),
-          ...incoming,
-          quantity: mergedQuantity,
-        })
+        const referenceQuantity = Math.max(previousServerQuantity, incoming.quantity)
+        const guestContribution = existingQuantity - referenceQuantity
+        const mergedQuantity = Math.max(incoming.quantity + guestContribution, 0)
+        if (mergedQuantity > 0) {
+          mergedMap.set(incoming.id, {
+            ...(existing ?? incoming),
+            ...incoming,
+            quantity: mergedQuantity,
+          })
+        } else {
+          mergedMap.delete(incoming.id)
+        }
         nextSnapshotEntries.push([incoming.id, incoming.quantity])
       }
 
@@ -271,11 +284,109 @@ export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (typeof window === 'undefined') return
     const handleAuthChange = () => {
       hasSyncedServerCartRef.current = false
+      isAuthenticatedRef.current = false
+      if (persistTimeoutRef.current) {
+        clearTimeout(persistTimeoutRef.current)
+        persistTimeoutRef.current = null
+      }
       syncCartFromServer()
     }
     window.addEventListener('dyad-auth-changed', handleAuthChange)
     return () => window.removeEventListener('dyad-auth-changed', handleAuthChange)
   }, [syncCartFromServer])
+
+  const persistCartToServer = useCallback(
+    async (items: CartItem[]) => {
+      if (!hasLoadedLocalCart || typeof window === 'undefined') return
+      if (!isAuthenticatedRef.current) return
+
+      const currentSnapshot = new Map<string, number>()
+      for (const item of items) {
+        if (!item?.id) continue
+        const quantity = Math.max(0, Math.floor(item.quantity))
+        if (quantity <= 0) continue
+        currentSnapshot.set(item.id, quantity)
+      }
+
+      const previousSnapshot = serverSnapshotRef.current
+      let isDifferent = currentSnapshot.size !== previousSnapshot.size
+      if (!isDifferent) {
+        for (const [id, quantity] of currentSnapshot.entries()) {
+          if ((previousSnapshot.get(id) ?? 0) !== quantity) {
+            isDifferent = true
+            break
+          }
+        }
+      }
+
+      if (!isDifferent) {
+        return
+      }
+
+      try {
+        const response = await fetch('/api/cart', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            items: Array.from(currentSnapshot.entries()).map(([id, quantity]) => ({
+              id,
+              quantity,
+            })),
+          }),
+        })
+
+        if (response.status === 401) {
+          isAuthenticatedRef.current = false
+          return
+        }
+
+        if (!response.ok) {
+          throw new Error(`Failed with status ${response.status}`)
+        }
+
+        isAuthenticatedRef.current = true
+
+        const data = (await response.json().catch(() => null)) as unknown
+        const snapshotRaw = isRecord(data) ? (data as Record<string, unknown>).snapshot : null
+        if (isRecord(snapshotRaw)) {
+          const nextEntries: [string, number][] = []
+          for (const [id, value] of Object.entries(snapshotRaw)) {
+            if (typeof id !== 'string') continue
+            const quantity = Number(value)
+            if (Number.isFinite(quantity) && quantity >= 0) {
+              nextEntries.push([id, Math.floor(quantity)])
+            }
+          }
+          serverSnapshotRef.current = new Map(nextEntries)
+        } else {
+          serverSnapshotRef.current = new Map(currentSnapshot)
+        }
+      } catch (error) {
+        console.error('Failed to persist cart to server:', error)
+      }
+    },
+    [hasLoadedLocalCart],
+  )
+
+  useEffect(() => {
+    if (!hasLoadedLocalCart) return
+    if (!isAuthenticatedRef.current) return
+    if (persistTimeoutRef.current) {
+      clearTimeout(persistTimeoutRef.current)
+    }
+    const itemsSnapshot = state.items
+    persistTimeoutRef.current = setTimeout(() => {
+      persistTimeoutRef.current = null
+      void persistCartToServer(itemsSnapshot)
+    }, 400)
+    return () => {
+      if (persistTimeoutRef.current) {
+        clearTimeout(persistTimeoutRef.current)
+        persistTimeoutRef.current = null
+      }
+    }
+  }, [state.items, hasLoadedLocalCart, persistCartToServer])
 
   // Send lightweight cart activity to server (for abandoned cart tracking)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add reusable cart helper utilities and extend the cart API with a POST endpoint plus a merge endpoint to combine guest carts with authenticated carts
- enhance the client cart context to track authentication state, merge server data safely, and persist cart changes back to the server when signed in
- merge guest cart contents during login by calling the new API and updating local storage to prevent duplicate merges

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cb65cfdbcc832aa11c9e134edf0670