### PR TITLE
Show delivery charge beside payment method on admin dashboard

### DIFF
--- a/src/app/(frontend)/admin-dashboard/page.tsx
+++ b/src/app/(frontend)/admin-dashboard/page.tsx
@@ -499,6 +499,11 @@ export default async function AdminDashboardPage({
                             <span className="font-medium text-gray-800">Method:</span>{' '}
                             {formatPaymentMethod(order.paymentMethod)}
                           </div>
+                          <div>
+                            <span className="font-medium text-gray-800">Delivery charge:</span>{' '}
+                            {fmtBDT(order.shippingCharge || 0)}
+                            {order.freeDeliveryApplied ? ' (Free delivery applied)' : ''}
+                          </div>
                           {isDigitalPayment(order.paymentMethod) ? (
                             <>
                               <div>


### PR DESCRIPTION
## Summary
- surface each order's delivery charge next to the payment method in the admin dashboard payment details
- highlight when a free delivery promotion was applied to the order

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cb8283ffd0832a904ab47041dd6251