### PR TITLE
Enable session-based cart sync

### DIFF
--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -8,6 +8,7 @@ import {
   buildQuantityMapFromIncoming,
   extractCartQuantities,
   findActiveCartForUser,
+  findCartBySession,
   generateSessionId,
   getDocId,
   getSessionIdFromDoc,
@@ -17,38 +18,74 @@ import {
   resolveUserId,
 } from './cart-helpers'
 
+const resolveSessionIdFromRequest = (request: NextRequest): string | null => {
+  const urlSession = request.nextUrl.searchParams.get('sessionId')
+  if (typeof urlSession === 'string' && urlSession.trim().length > 0) {
+    return urlSession.trim()
+  }
+
+  const headerSession = request.headers.get('x-dyad-cart-session')
+  if (typeof headerSession === 'string' && headerSession.trim().length > 0) {
+    return headerSession.trim()
+  }
+
+  const cookieSession = request.cookies.get('dyad_cart_sid')?.value
+  if (typeof cookieSession === 'string' && cookieSession.trim().length > 0) {
+    return cookieSession.trim()
+  }
+
+  return null
+}
+
+const applySessionCookie = (response: NextResponse, sessionId: string | null) => {
+  if (!sessionId) return
+
+  response.cookies.set('dyad_cart_sid', String(sessionId), {
+    path: '/',
+    httpOnly: false,
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 30,
+  })
+}
+
 export async function GET(request: NextRequest) {
   try {
     const payload = await getPayload({ config: await config })
     const { user } = await payload.auth({ headers: request.headers })
 
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
     const userId = resolveUserId(user)
-    if (typeof userId !== 'number') {
-      return NextResponse.json({ items: [], total: 0 })
+    const sessionCandidate = resolveSessionIdFromRequest(request)
+
+    let cartDoc: Record<string, unknown> | null = null
+
+    if (typeof userId === 'number') {
+      cartDoc = await findActiveCartForUser(payload, userId)
     }
 
-    const cartDoc = await findActiveCartForUser(payload, userId)
-
-    if (!cartDoc) {
-      return NextResponse.json({ items: [], total: 0 })
+    if (!cartDoc && sessionCandidate) {
+      cartDoc = await findCartBySession(payload, sessionCandidate)
     }
 
     const quantityMap = extractCartQuantities(cartDoc)
-    const { serialized, total: computedTotal } = await resolveCartPayload(payload, quantityMap)
+    const { serialized, total: computedTotal, snapshot } = await resolveCartPayload(payload, quantityMap)
 
-    const totalRaw = isRecord(cartDoc) && typeof cartDoc.cartTotal === 'number' ? cartDoc.cartTotal : undefined
+    const totalRaw = isRecord(cartDoc) && typeof cartDoc?.cartTotal === 'number' ? cartDoc.cartTotal : undefined
     const total = typeof totalRaw === 'number' ? totalRaw : computedTotal
 
-    return NextResponse.json({
+    const resolvedSessionId =
+      getSessionIdFromDoc(cartDoc) ?? sessionCandidate ?? (serialized.length > 0 ? generateSessionId() : null)
+
+    const response = NextResponse.json({
       items: serialized,
       total,
-      sourceUpdatedAt: isRecord(cartDoc) && typeof cartDoc.updatedAt === 'string' ? cartDoc.updatedAt : null,
-      sessionId: getSessionIdFromDoc(cartDoc),
+      sourceUpdatedAt: isRecord(cartDoc) && typeof cartDoc?.updatedAt === 'string' ? cartDoc.updatedAt : null,
+      sessionId: resolvedSessionId,
+      snapshot,
     })
+
+    applySessionCookie(response, resolvedSessionId)
+
+    return response
   } catch (error) {
     console.error('Failed to load persisted cart:', error)
     return NextResponse.json({ error: 'Failed to load cart' }, { status: 500 })
@@ -60,36 +97,38 @@ export async function POST(request: NextRequest) {
     const payload = await getPayload({ config: await config })
     const { user } = await payload.auth({ headers: request.headers })
 
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
     const userId = resolveUserId(user)
-    if (typeof userId !== 'number') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
     const body = await request.json().catch(() => null)
     const itemsInput = isRecord(body) ? body.items : null
     const payloadSessionId =
       isRecord(body) && typeof body.sessionId === 'string' && body.sessionId.trim().length > 0
         ? body.sessionId.trim()
         : undefined
+    const requestSessionId = resolveSessionIdFromRequest(request)
     const incomingItems = normalizeIncomingItems(itemsInput)
     const quantityMap = buildQuantityMapFromIncoming(incomingItems)
 
-    const cartDoc = await findActiveCartForUser(payload, userId)
+    let cartDoc: Record<string, unknown> | null = null
+    if (typeof userId === 'number') {
+      cartDoc = await findActiveCartForUser(payload, userId)
+    }
+
+    const sessionCandidate = payloadSessionId ?? requestSessionId ?? null
+
+    if (!cartDoc && sessionCandidate) {
+      cartDoc = await findCartBySession(payload, sessionCandidate)
+    }
+
     const resolved = await resolveCartPayload(payload, quantityMap)
 
     const existingSession = getSessionIdFromDoc(cartDoc)
-    const cookieSession = request.cookies.get('dyad_cart_sid')?.value
-    const sessionId = existingSession ?? payloadSessionId ?? cookieSession ?? generateSessionId()
+    const sessionId = existingSession ?? sessionCandidate ?? generateSessionId()
 
     const nowIso = new Date().toISOString()
 
     const data: Omit<AbandonedCart, 'id' | 'createdAt' | 'updatedAt'> = {
       sessionId,
-      user: userId,
+      user: typeof userId === 'number' ? userId : null,
       items: resolved.lines,
       cartTotal: resolved.total,
       status: 'active',
@@ -122,14 +161,7 @@ export async function POST(request: NextRequest) {
       sessionId,
     })
 
-    if (sessionId) {
-      response.cookies.set('dyad_cart_sid', String(sessionId), {
-        path: '/',
-        httpOnly: false,
-        sameSite: 'lax',
-        maxAge: 60 * 60 * 24 * 30,
-      })
-    }
+    applySessionCookie(response, sessionId)
 
     return response
   } catch (error) {


### PR DESCRIPTION
## Summary
- allow the cart API to resolve carts by anonymous session ids and return a snapshot for client reconciliation
- reuse the session id cookie across responses so guest carts can persist and sync across devices
- update the client cart context to request the correct session, merge server snapshots, and persist carts without requiring auth

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cb81ebb43c832aa8d538d24e15727f