### PR TITLE
Fix cart persistence and profile delivery zone updates

### DIFF
--- a/src/app/api/cart/cart-helpers.ts
+++ b/src/app/api/cart/cart-helpers.ts
@@ -25,11 +25,13 @@ export const toItemId = (value: unknown): number | null => {
   return null
 }
 
-export const resolveUserId = (user: unknown): number | null => {
+export const resolveUserId = (user: unknown): number | string | null => {
   if (!isRecord(user)) return null
   const idRaw = user.id
   if (typeof idRaw === 'number' && Number.isFinite(idRaw)) return idRaw
-  return toItemId(idRaw)
+  if (typeof idRaw === 'string' && idRaw.trim().length > 0) return idRaw.trim()
+  const numeric = toItemId(idRaw)
+  return numeric
 }
 
 const pickCategoryName = (value: unknown): string => {
@@ -222,7 +224,7 @@ export const buildSnapshotMap = (items: SerializedCartItem[]): Record<string, nu
 
 export const findActiveCartForUser = async (
   payload: Payload,
-  userId: number,
+  userId: number | string,
 ): Promise<Record<string, unknown> | null> => {
   const query = await payload.find({
     collection: 'abandoned-carts',

--- a/src/app/api/cart/merge/route.ts
+++ b/src/app/api/cart/merge/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
     }
 
     const userId = resolveUserId(user)
-    if (typeof userId !== 'number') {
+    if (typeof userId !== 'number' && typeof userId !== 'string') {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
@@ -98,7 +98,7 @@ export async function POST(request: NextRequest) {
 
     const data: Omit<AbandonedCart, 'id' | 'createdAt' | 'updatedAt'> = {
       sessionId,
-      user: userId,
+      user: userId as any,
       items: resolved.lines,
       cartTotal: resolved.total,
       status: 'active',

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -58,7 +58,7 @@ export async function GET(request: NextRequest) {
 
     let cartDoc: Record<string, unknown> | null = null
 
-    if (typeof userId === 'number') {
+    if (typeof userId === 'number' || typeof userId === 'string') {
       cartDoc = await findActiveCartForUser(payload, userId)
     }
 
@@ -109,7 +109,7 @@ export async function POST(request: NextRequest) {
     const quantityMap = buildQuantityMapFromIncoming(incomingItems)
 
     let cartDoc: Record<string, unknown> | null = null
-    if (typeof userId === 'number') {
+    if (typeof userId === 'number' || typeof userId === 'string') {
       cartDoc = await findActiveCartForUser(payload, userId)
     }
 
@@ -128,7 +128,7 @@ export async function POST(request: NextRequest) {
 
     const data: Omit<AbandonedCart, 'id' | 'createdAt' | 'updatedAt'> = {
       sessionId,
-      user: typeof userId === 'number' ? userId : null,
+      user: typeof userId === 'number' || typeof userId === 'string' ? (userId as any) : null,
       items: resolved.lines,
       cartTotal: resolved.total,
       status: 'active',

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -13,6 +13,7 @@ export async function GET(request: NextRequest) {
     firstName: (user as any).firstName,
     lastName: (user as any).lastName,
     customerNumber: (user as any).customerNumber || null,
+    deliveryZone: (user as any).deliveryZone || null,
     address: (user as any).address || null,
   })
 }
@@ -30,6 +31,13 @@ export async function PATCH(request: NextRequest) {
     if (typeof body.lastName === 'string') data.lastName = body.lastName
     if (typeof body.email === 'string') data.email = body.email
     if (typeof body.customerNumber === 'string') data.customerNumber = body.customerNumber
+
+    if (typeof body.deliveryZone === 'string') {
+      const normalized = body.deliveryZone.toLowerCase().replace(/[\s-]+/g, '_')
+      if (normalized === 'outside_dhaka' || normalized === 'inside_dhaka') {
+        data.deliveryZone = normalized
+      }
+    }
     if (body.address && typeof body.address === 'object') {
       const a = body.address
       data.address = {


### PR DESCRIPTION
## Summary
- allow cart helpers and API routes to associate carts with users that have string identifiers so logged-in carts persist across sessions
- include the saved delivery zone when returning the current user and normalize delivery zone updates from the profile form

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cb86791e04832aac7bc4370cc96e78