### PR TITLE
Highlight digital wallet delivery notice

### DIFF
--- a/src/app/(frontend)/checkout/checkout-form.tsx
+++ b/src/app/(frontend)/checkout/checkout-form.tsx
@@ -470,7 +470,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
             A flat delivery charge of {formatCurrency(settings.digitalPaymentDeliveryCharge)} applies to digital wallet payments.
           </p>
         ) : (
-          <p className="text-xs text-gray-500">
+          <p className="text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
             Digital wallet payments below {formatCurrency(settings.freeDeliveryThreshold)} have a flat delivery charge of{' '}
             {formatCurrency(settings.digitalPaymentDeliveryCharge)}.
           </p>


### PR DESCRIPTION
## Summary
- update the checkout delivery charge reminder to use the highlighted callout styling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cbbb9d9260832aa3052514ea7f32c3