### PR TITLE
Add abandoned cart reminder workflow

### DIFF
--- a/src/app/api/abandoned-carts/reminders/route.ts
+++ b/src/app/api/abandoned-carts/reminders/route.ts
@@ -1,0 +1,367 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+
+import type { AbandonedCart } from '@/payload-types'
+
+import config from '@/payload.config'
+
+const HOUR_IN_MS = 60 * 60 * 1000
+
+const STAGE_CONFIGS = [
+  {
+    stage: 1,
+    waitHours: 24,
+    minHoursSinceLastReminder: 0,
+    subject: 'আপনার কার্টে থাকা পণ্যগুলো অপেক্ষায় আছে',
+    headline: 'আপনার পছন্দের পণ্যগুলো এখনও সংরক্ষিত আছে।',
+    intro:
+      'আপনি আমাদের স্টোরে কিছু পণ্য কার্টে যোগ করেছিলেন কিন্তু অর্ডার সম্পন্ন করতে পারেননি। চিন্তা নেই, আমরা এগুলো এখনও আপনার জন্য ধরে রেখেছি।',
+    followUp: 'মাত্র এক ক্লিকে এখনই ফিরে এসে অর্ডার নিশ্চিত করুন।',
+  },
+  {
+    stage: 2,
+    waitHours: 48,
+    minHoursSinceLastReminder: 24,
+    subject: 'দ্বিতীয় রিমাইন্ডার: আপনার কার্টে থাকা পণ্যগুলো মিস করবেন না',
+    headline: 'দুই দিন হয়ে গেল — পণ্যগুলো এখনও আপনার জন্য অপেক্ষায়।',
+    intro:
+      'আপনার কার্টে থাকা পণ্যগুলো দ্রুত শেষ হয়ে যেতে পারে। যদি এখনও আগ্রহী থাকেন, এখনই অর্ডার করে নিশ্চিত করুন।',
+    followUp: 'আপনার কার্ট পুনরুদ্ধার করুন এবং অর্ডার সম্পন্ন করুন।',
+  },
+  {
+    stage: 3,
+    waitHours: 72,
+    minHoursSinceLastReminder: 24,
+    subject: 'শেষ রিমাইন্ডার: পণ্যগুলো চলে যেতে পারে',
+    headline: 'এই হলো আপনার শেষ সুযোগ — স্টক শেষ হওয়ার আগেই অর্ডার করুন।',
+    intro:
+      'তিন দিন আগে আপনি যেসব পণ্য কার্টে রেখেছিলেন আমরা সেগুলো ধরে রেখেছি। আর দেরি হলে পণ্যগুলো অন্য কেউ নিয়ে নিতে পারে।',
+    followUp: 'আজই অর্ডার সম্পন্ন করুন এবং অফারটি উপভোগ করুন।',
+  },
+] as const
+
+type StageConfig = (typeof STAGE_CONFIGS)[number]
+
+const escapeHtml = (value: string): string =>
+  value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;'
+      case '<':
+        return '&lt;'
+      case '>':
+        return '&gt;'
+      case '"':
+        return '&quot;'
+      case "'":
+        return '&#39;'
+      default:
+        return char
+    }
+  })
+
+const formatCurrency = (value?: number | null): string => {
+  const amount = typeof value === 'number' && Number.isFinite(value) ? value : 0
+  return `৳${amount.toFixed(2)}`
+}
+
+const resolveServerURL = (payloadInstance: Awaited<ReturnType<typeof getPayload>> | null): string => {
+  const fromConfig = (payloadInstance?.config as any)?.serverURL
+  const envURL = process.env.NEXT_PUBLIC_SERVER_URL
+  const raw = typeof fromConfig === 'string' && fromConfig.length > 0 ? fromConfig : envURL
+  if (!raw) return ''
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw
+}
+
+const normalizeReminderStage = (cart: AbandonedCart | Record<string, unknown>): number => {
+  const raw = (cart as any)?.reminderStage
+  const parsed = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0
+  return Math.max(0, Math.min(parsed, 3))
+}
+
+const hasValidEmail = (cart: AbandonedCart | Record<string, unknown>): cart is AbandonedCart => {
+  const email = (cart as any)?.customerEmail
+  if (typeof email !== 'string') return false
+  const trimmed = email.trim()
+  if (!trimmed) return false
+  return trimmed.includes('@')
+}
+
+const buildEmailContent = (
+  cart: AbandonedCart,
+  stage: StageConfig,
+  serverURL: string,
+): { html: string; text: string } => {
+  const customerName =
+    (typeof cart.customerName === 'string' && cart.customerName.trim().length > 0
+      ? cart.customerName.trim()
+      : null) ||
+    (typeof cart.customerEmail === 'string' ? cart.customerEmail.split('@')[0] : 'গ্রাহক')
+
+  const checkoutUrl = serverURL ? `${serverURL}/checkout` : ''
+  const items = Array.isArray(cart.items) ? cart.items : []
+
+  const detailedItems = items
+    .map((entry) => {
+      const quantityRaw = Number((entry as any)?.quantity)
+      const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0 ? Math.floor(quantityRaw) : 0
+      if (quantity <= 0) return null
+      const itemRef = (entry as any)?.item
+      let name = 'পণ্য'
+      let unitPrice: number | undefined
+      if (itemRef && typeof itemRef === 'object') {
+        const maybeName = (itemRef as any)?.name
+        const maybePrice = (itemRef as any)?.price
+        if (typeof maybeName === 'string' && maybeName.trim()) {
+          name = maybeName.trim()
+        }
+        if (typeof maybePrice === 'number' && Number.isFinite(maybePrice)) {
+          unitPrice = maybePrice
+        }
+      } else if (typeof itemRef === 'number') {
+        name = `পণ্য #${itemRef}`
+      } else if (typeof itemRef === 'string') {
+        name = itemRef
+      }
+      return {
+        name,
+        quantity,
+        unitPrice,
+        lineTotal: typeof unitPrice === 'number' ? unitPrice * quantity : undefined,
+      }
+    })
+    .filter((entry): entry is {
+      name: string
+      quantity: number
+      unitPrice?: number
+      lineTotal?: number
+    } => entry !== null)
+
+  const fallbackTotal = typeof cart.cartTotal === 'number' ? cart.cartTotal : undefined
+  const computedTotal = detailedItems.reduce((sum, item) => sum + (item.lineTotal ?? 0), 0)
+  const totalValue = computedTotal > 0 ? computedTotal : fallbackTotal ?? 0
+
+  const itemRowsHTML = detailedItems
+    .map((item) => {
+      const quantityLabel = `${item.quantity}`
+      const priceLabel =
+        typeof item.lineTotal === 'number' && item.lineTotal > 0
+          ? formatCurrency(item.lineTotal)
+          : item.unitPrice
+            ? formatCurrency(item.unitPrice * item.quantity)
+            : `${item.quantity} pcs`
+      return `
+        <tr>
+          <td style="padding:8px;border:1px solid #e5e7eb;">${escapeHtml(item.name)}</td>
+          <td style="padding:8px;border:1px solid #e5e7eb;text-align:center;">${escapeHtml(quantityLabel)}</td>
+          <td style="padding:8px;border:1px solid #e5e7eb;text-align:right;">${escapeHtml(priceLabel)}</td>
+        </tr>
+      `
+    })
+    .join('')
+
+  const itemRowsText = detailedItems
+    .map((item) => {
+      const priceLabel =
+        typeof item.lineTotal === 'number' && item.lineTotal > 0
+          ? formatCurrency(item.lineTotal)
+          : item.unitPrice
+            ? formatCurrency(item.unitPrice * item.quantity)
+            : `${item.quantity} pcs`
+      return `- ${item.name} × ${item.quantity} = ${priceLabel}`
+    })
+    .join('\n')
+
+  const totalLabel = formatCurrency(totalValue)
+
+  const greeting = `হ্যালো ${customerName},`
+
+  const ctaButton = checkoutUrl
+    ? `
+        <p style="margin:24px 0;">
+          <a href="${checkoutUrl}" style="display:inline-block;background-color:#dc2626;color:#ffffff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;">
+            অর্ডার সম্পন্ন করুন
+          </a>
+        </p>
+      `
+    : ''
+
+  const html = `
+    <div style="font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#111827;">
+      <p>${escapeHtml(greeting)}</p>
+      <h2 style="font-size:18px;margin:16px 0 8px 0;">${escapeHtml(stage.headline)}</h2>
+      <p style="margin:8px 0;">${escapeHtml(stage.intro)}</p>
+      <p style="margin:8px 0;">${escapeHtml(stage.followUp)}</p>
+      ${itemRowsHTML
+        ? `
+            <table cellpadding="0" cellspacing="0" style="border-collapse:collapse;border:1px solid #e5e7eb;width:100%;max-width:520px;margin:16px 0;">
+              <thead>
+                <tr>
+                  <th align="left" style="padding:8px;border:1px solid #e5e7eb;background:#f9fafb;">পণ্য</th>
+                  <th align="center" style="padding:8px;border:1px solid #e5e7eb;background:#f9fafb;">পরিমাণ</th>
+                  <th align="right" style="padding:8px;border:1px solid #e5e7eb;background:#f9fafb;">মূল্য</th>
+                </tr>
+              </thead>
+              <tbody>${itemRowsHTML}</tbody>
+            </table>
+          `
+        : ''}
+      <p style="margin:8px 0;font-weight:600;">মোট মূল্য: ${escapeHtml(totalLabel)}</p>
+      ${ctaButton}
+      <p style="margin:8px 0;">অর্ডার সম্পন্ন করার জন্য আপনার পূর্বের তথ্য আমরা সংরক্ষণ করে রেখেছি। শুধু লগইন করুন এবং পেমেন্ট নিশ্চিত করুন।</p>
+      <p style="margin:16px 0 0 0;">শুভেচ্ছান্তে,<br/>Portal Mini Store টিম</p>
+    </div>
+  `
+
+  const textParts = [
+    greeting,
+    '',
+    stage.headline,
+    stage.intro,
+    stage.followUp,
+    '',
+    itemRowsText,
+    '',
+    `মোট মূল্য: ${totalLabel}`,
+    checkoutUrl ? `অর্ডার সম্পন্ন করুন: ${checkoutUrl}` : '',
+    '',
+    'শুভেচ্ছান্তে,',
+    'Portal Mini Store টিম',
+  ].filter(Boolean)
+
+  return { html, text: textParts.join('\n') }
+}
+
+const shouldSendForStage = (cart: AbandonedCart, stage: StageConfig, now: number): boolean => {
+  if (!hasValidEmail(cart)) return false
+  const reminderStage = normalizeReminderStage(cart)
+  if (stage.stage === 1) {
+    return reminderStage <= 0
+  }
+  if (reminderStage !== stage.stage - 1) {
+    return false
+  }
+  const lastReminderAt = cart.recoveryEmailSentAt ? Date.parse(cart.recoveryEmailSentAt) : NaN
+  if (!Number.isFinite(lastReminderAt)) {
+    return false
+  }
+  const minGapMs = stage.minHoursSinceLastReminder * HOUR_IN_MS
+  return now - lastReminderAt >= minGapMs
+}
+
+const runReminderJob = async (payloadInstance: Awaited<ReturnType<typeof getPayload>>) => {
+  const results: Array<{
+    stage: number
+    attempted: number
+    sent: number
+    errors: number
+  }> = []
+
+  const now = Date.now()
+  const serverURL = resolveServerURL(payloadInstance)
+
+  for (const stage of STAGE_CONFIGS) {
+    const cutoff = new Date(now - stage.waitHours * HOUR_IN_MS).toISOString()
+    const query = await payloadInstance.find({
+      collection: 'abandoned-carts',
+      depth: 2,
+      limit: 250,
+      sort: 'lastActivityAt',
+      where: {
+        and: [
+          { status: { not_equals: 'recovered' } },
+          { lastActivityAt: { less_than: cutoff } },
+        ],
+      },
+    })
+
+    const stageResult = { stage: stage.stage, attempted: 0, sent: 0, errors: 0 }
+
+    for (const raw of query.docs as AbandonedCart[]) {
+      if (!raw) continue
+      if (!shouldSendForStage(raw, stage, now)) continue
+
+      stageResult.attempted += 1
+
+      try {
+        const { html, text } = buildEmailContent(raw, stage, serverURL)
+        await payloadInstance.sendEmail?.({
+          to: String(raw.customerEmail),
+          subject: stage.subject,
+          html,
+          text,
+        })
+
+        await payloadInstance.update({
+          collection: 'abandoned-carts',
+          id: (raw as any).id,
+          data: {
+            reminderStage: stage.stage,
+            recoveryEmailSentAt: new Date(now).toISOString(),
+            status: raw.status === 'active' ? 'abandoned' : raw.status,
+          },
+        })
+
+        stageResult.sent += 1
+      } catch (error) {
+        console.error(`Failed to send reminder for cart ${String((raw as any).id)}:`, error)
+        stageResult.errors += 1
+      }
+    }
+
+    results.push(stageResult)
+  }
+
+  return { results }
+}
+
+const ensureEmailSupport = (payloadInstance: Awaited<ReturnType<typeof getPayload>>) => {
+  if (typeof payloadInstance?.sendEmail !== 'function') {
+    throw new Error('Email transport is not configured for Payload')
+  }
+}
+
+const handleCronAuthorization = (request: NextRequest) => {
+  const isVercelCron = !!request.headers.get('x-vercel-cron')
+  const url = new URL(request.url)
+  const providedSecret = url.searchParams.get('secret') || request.headers.get('x-cron-secret')
+  const hasSecret = !!process.env.CRON_SECRET && providedSecret === process.env.CRON_SECRET
+  return { authorized: isVercelCron || hasSecret, via: isVercelCron ? 'vercel-cron' : hasSecret ? 'secret' : 'unknown' }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { authorized, via } = handleCronAuthorization(request)
+    if (!authorized) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const payloadInstance = await getPayload({ config: await config })
+    ensureEmailSupport(payloadInstance)
+
+    const outcome = await runReminderJob(payloadInstance)
+    return NextResponse.json({ success: true, via, ...outcome })
+  } catch (error) {
+    console.error('Failed to process abandoned cart reminders:', error)
+    return NextResponse.json({ error: 'Failed to send reminders' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const payloadInstance = await getPayload({ config: await config })
+    const { user } = await payloadInstance.auth({ headers: request.headers })
+
+    if (!user || (user as any)?.role !== 'admin') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    ensureEmailSupport(payloadInstance)
+
+    const outcome = await runReminderJob(payloadInstance)
+    return NextResponse.json({ success: true, via: 'admin', ...outcome })
+  } catch (error) {
+    console.error('Failed to process abandoned cart reminders (admin):', error)
+    return NextResponse.json({ error: 'Failed to send reminders' }, { status: 500 })
+  }
+}

--- a/src/app/api/cart-activity/route.ts
+++ b/src/app/api/cart-activity/route.ts
@@ -89,6 +89,7 @@ export async function POST(request: NextRequest) {
       ...(typeof total === 'number' ? { cartTotal: total } : {}),
       status: 'active',
       lastActivityAt: now,
+      reminderStage: 0,
     }
 
     let doc

--- a/src/app/api/cart/merge/route.ts
+++ b/src/app/api/cart/merge/route.ts
@@ -108,6 +108,7 @@ export async function POST(request: NextRequest) {
       customerNumber: null,
       recoveredOrder: null,
       recoveryEmailSentAt: null,
+      reminderStage: 0,
       notes: null,
     }
 

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -126,6 +126,7 @@ export async function POST(request: NextRequest) {
       customerNumber: null,
       recoveredOrder: null,
       recoveryEmailSentAt: null,
+      reminderStage: 0,
       notes: null,
     }
 

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -311,6 +311,8 @@ export async function POST(request: NextRequest) {
             data: {
               status: 'recovered',
               recoveredOrder: (order as any).id,
+              reminderStage: 3,
+              recoveryEmailSentAt: new Date().toISOString(),
             } as any,
           })
         }

--- a/src/collections/AbandonedCarts.ts
+++ b/src/collections/AbandonedCarts.ts
@@ -88,6 +88,17 @@ export const AbandonedCarts: CollectionConfig = {
       required: true,
     },
     {
+      name: 'reminderStage',
+      type: 'number',
+      required: false,
+      defaultValue: 0,
+      min: 0,
+      max: 3,
+      admin: {
+        description: 'How many recovery reminder emails have been sent',
+      },
+    },
+    {
       name: 'lastActivityAt',
       type: 'date',
       required: true,

--- a/src/migrations/20250914_add_abandoned_cart_reminder_stage.ts
+++ b/src/migrations/20250914_add_abandoned_cart_reminder_stage.ts
@@ -1,0 +1,31 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-vercel-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'abandoned_carts' AND column_name = 'reminder_stage'
+      ) THEN
+        ALTER TABLE "abandoned_carts" ADD COLUMN "reminder_stage" integer DEFAULT 0;
+        UPDATE "abandoned_carts" SET "reminder_stage" = COALESCE("reminder_stage", 0);
+        ALTER TABLE "abandoned_carts" ALTER COLUMN "reminder_stage" SET NOT NULL;
+      END IF;
+    END $$;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'abandoned_carts' AND column_name = 'reminder_stage'
+      ) THEN
+        ALTER TABLE "abandoned_carts" DROP COLUMN "reminder_stage";
+      END IF;
+    END $$;
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -18,7 +18,6 @@ import * as migration_20250917_add_delivery_settings from './20250917_add_delive
 import * as migration_20250917_add_delivery_settings_lock_rel from './20250917_add_delivery_settings_lock_rel';
 import * as migration_20250918_add_payment_fields_to_orders from './20250918_add_payment_fields_to_orders';
 import * as migration_20250919_update_delivery_settings_with_highlight from './20250919_update_delivery_settings_with_highlight';
-import * as migration_20250914_add_abandoned_cart_reminder_stage from './20250914_add_abandoned_cart_reminder_stage';
 
 export const migrations = [
   {

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -12,11 +12,13 @@ import * as migration_20250912_add_reviewer_name_to_reviews from './20250912_add
 import * as migration_20250912_make_orders_items_item_nullable from './20250912_make_orders_items_item_nullable';
 import * as migration_20250912_add_device_fields_to_orders from './20250912_add_device_fields_to_orders';
 import * as migration_20250913_add_abandoned_carts from './20250913_add_abandoned_carts';
+import * as migration_20250914_add_abandoned_cart_reminder_stage from './20250914_add_abandoned_cart_reminder_stage';
 import * as migration_20250916_add_short_description_to_items from './20250916_add_short_description_to_items';
 import * as migration_20250917_add_delivery_settings from './20250917_add_delivery_settings';
 import * as migration_20250917_add_delivery_settings_lock_rel from './20250917_add_delivery_settings_lock_rel';
 import * as migration_20250918_add_payment_fields_to_orders from './20250918_add_payment_fields_to_orders';
 import * as migration_20250919_update_delivery_settings_with_highlight from './20250919_update_delivery_settings_with_highlight';
+import * as migration_20250914_add_abandoned_cart_reminder_stage from './20250914_add_abandoned_cart_reminder_stage';
 
 export const migrations = [
   {
@@ -88,6 +90,11 @@ export const migrations = [
     up: migration_20250913_add_abandoned_carts.up,
     down: migration_20250913_add_abandoned_carts.down,
     name: '20250913_add_abandoned_carts',
+  },
+  {
+    up: migration_20250914_add_abandoned_cart_reminder_stage.up,
+    down: migration_20250914_add_abandoned_cart_reminder_stage.down,
+    name: '20250914_add_abandoned_cart_reminder_stage',
   },
   {
     up: migration_20250916_add_short_description_to_items.up,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -329,6 +329,7 @@ export interface AbandonedCart {
     | null;
   cartTotal?: number | null;
   status: 'active' | 'abandoned' | 'recovered';
+  reminderStage?: number | null;
   lastActivityAt: string;
   recoveredOrder?: (number | null) | Order;
   recoveryEmailSentAt?: string | null;
@@ -592,6 +593,7 @@ export interface AbandonedCartsSelect<T extends boolean = true> {
       };
   cartTotal?: T;
   status?: T;
+  reminderStage?: T;
   lastActivityAt?: T;
   recoveredOrder?: T;
   recoveryEmailSentAt?: T;


### PR DESCRIPTION
## Summary
- add reminderStage tracking and migration so abandoned carts stay linked to accounts across devices
- persist reminder state when carts change and stop reminders once an order is placed
- add a cron-enabled reminders API that emails customers after 24h, 48h, and 72h with localized messaging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cbc8ca5370832aa93c2a3e974bcdff