### PR TITLE
Align checkout and order layout with site theme

### DIFF
--- a/src/app/(frontend)/checkout/checkout-form.tsx
+++ b/src/app/(frontend)/checkout/checkout-form.tsx
@@ -7,10 +7,10 @@ import Image from 'next/image'
 
 import { useCart } from '@/lib/cart-context'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Minus, Plus, ShieldCheck, Store, Truck } from 'lucide-react'
 import type { DeliverySettings } from '@/lib/delivery-settings'
 import { DEFAULT_DELIVERY_SETTINGS } from '@/lib/delivery-settings'
 import { cn } from '@/lib/utils'
@@ -27,7 +27,7 @@ interface CheckoutFormProps {
 }
 
 export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettings }) => {
-  const { state, clearCart, getTotalPrice } = useCart()
+  const { state, clearCart, getTotalPrice, updateQuantity } = useCart()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [customerNumber, setCustomerNumber] = useState<string>(user?.customerNumber || '')
@@ -39,6 +39,7 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
   const [email, setEmail] = useState<string>(user?.email || '')
   const [address_line1, setAddressLine1] = useState<string>(user?.address?.line1 || '')
   const [address_line2, setAddressLine2] = useState<string>(user?.address?.line2 || '')
+  const [discountCode, setDiscountCode] = useState<string>('')
   const initialDeliveryZone: 'inside_dhaka' | 'outside_dhaka' =
     user?.deliveryZone === 'outside_dhaka' ? 'outside_dhaka' : 'inside_dhaka'
   const [deliveryZone, setDeliveryZone] = useState<'inside_dhaka' | 'outside_dhaka'>(initialDeliveryZone)
@@ -65,6 +66,155 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
   const requiresDigitalPaymentDetails = isDigitalPayment
   const digitalPaymentInstructions = DIGITAL_PAYMENT_INSTRUCTIONS[paymentMethod]
   const isInsideDhaka = deliveryZone === 'inside_dhaka'
+  const formId = React.useId()
+  const inputClasses =
+    'block w-full rounded-xl border border-stone-200 bg-white/85 px-4 py-2.5 text-sm text-stone-700 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-amber-400/70 focus:ring-offset-0'
+  const SectionCard = ({
+    title,
+    description,
+    children,
+    className,
+  }: {
+    title: string
+    description?: string
+    children: React.ReactNode
+    className?: string
+  }) => (
+    <div className={cn('rounded-2xl border border-amber-100/70 bg-white/85 p-6 shadow-sm shadow-amber-200/40', className)}>
+      <div>
+        <h3 className="text-lg font-semibold text-stone-900">{title}</h3>
+        {description ? <p className="mt-1 text-sm text-stone-500">{description}</p> : null}
+      </div>
+      <div className="mt-5 space-y-5">{children}</div>
+    </div>
+  )
+  const OrderSummaryCard = ({ className, layout }: { className?: string; layout: 'desktop' | 'mobile' }) => (
+    <div
+      className={cn(
+        'rounded-[26px] border border-amber-100/80 bg-white/90 p-6 shadow-xl shadow-amber-200/60 backdrop-blur-sm',
+        layout === 'desktop' ? 'lg:sticky lg:top-28' : '',
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-stone-900">Review your cart</h3>
+          <p className="text-sm text-stone-500">Double-check the details before you place your order.</p>
+        </div>
+        <Badge className="ml-auto h-7 rounded-full bg-amber-100 px-3 text-xs font-medium text-amber-700">
+          Secure checkout
+        </Badge>
+      </div>
+      <div className="mt-5 space-y-4">
+        {state.items.map((item) => (
+          <div
+            key={item.id}
+            className="flex items-start gap-4 rounded-2xl border border-amber-50 bg-white/85 p-4 shadow-sm shadow-amber-200/40"
+          >
+            {item.image ? (
+              <div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-xl border border-amber-100 bg-amber-50">
+                <Image
+                  src={item.image.url}
+                  alt={item.image.alt || item.name}
+                  fill
+                  sizes="64px"
+                  className="object-cover"
+                />
+              </div>
+            ) : null}
+            <div className="min-w-0 flex-1 space-y-1">
+              <div className="flex items-center gap-2">
+                <h4 className="truncate text-sm font-semibold text-stone-900">{item.name}</h4>
+                {item.category ? (
+                  <Badge className="hidden rounded-full bg-stone-100 px-2.5 py-0.5 text-[11px] font-medium text-stone-600 sm:inline-flex">
+                    {item.category}
+                  </Badge>
+                ) : null}
+              </div>
+              <p className="text-xs text-stone-500">{formatCurrency(item.price)} each</p>
+            </div>
+            <div className="flex flex-col items-end gap-3 text-right">
+              <div className="flex items-center gap-2 rounded-full border border-stone-200 bg-white/80 px-2 py-1 shadow-sm">
+                <button
+                  type="button"
+                  onClick={() => updateQuantity(item.id, Math.max(1, item.quantity - 1))}
+                  disabled={item.quantity <= 1}
+                  aria-label={`Decrease quantity of ${item.name}`}
+                  className="flex h-7 w-7 items-center justify-center rounded-full text-stone-500 transition hover:bg-amber-50 hover:text-amber-600 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white"
+                >
+                  <Minus className="h-4 w-4" />
+                </button>
+                <span className="min-w-[2ch] text-sm font-semibold text-stone-900">{item.quantity}</span>
+                <button
+                  type="button"
+                  onClick={() => updateQuantity(item.id, item.quantity + 1)}
+                  aria-label={`Increase quantity of ${item.name}`}
+                  className="flex h-7 w-7 items-center justify-center rounded-full text-stone-500 transition hover:bg-amber-50 hover:text-amber-600"
+                >
+                  <Plus className="h-4 w-4" />
+                </button>
+              </div>
+              <p className="text-sm font-semibold text-stone-900">{formatCurrency(item.price * item.quantity)}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-6 space-y-3">
+        <label htmlFor={`discount-${layout}`} className="text-sm font-semibold text-stone-700">
+          Discount code
+        </label>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <input
+            id={`discount-${layout}`}
+            type="text"
+            value={discountCode}
+            onChange={(e) => setDiscountCode(e.target.value)}
+            placeholder="Enter promo code"
+            className="flex-1 rounded-xl border border-stone-200 bg-white px-4 py-2 text-sm text-stone-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400/70"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            className="rounded-xl border-amber-200 bg-amber-50 text-amber-700 shadow-sm transition hover:bg-amber-100"
+          >
+            Apply
+          </Button>
+        </div>
+        <p className="text-xs text-stone-500">Promotions are applied before taxes and shipping charges.</p>
+      </div>
+      <Separator className="my-6" />
+      <div className="space-y-3 text-sm text-stone-600">
+        <div className="flex items-center justify-between">
+          <span>Subtotal</span>
+          <span className="font-medium text-stone-900">{formatCurrency(subtotal)}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>
+            Shipping {deliveryZone === 'outside_dhaka' ? '(Outside Dhaka)' : '(Inside Dhaka)'}
+          </span>
+          <span className="font-medium text-stone-900">{freeDelivery ? 'Free' : formatCurrency(shippingCharge)}</span>
+        </div>
+        <div className="flex items-center justify-between text-base font-semibold text-stone-900">
+          <span>Total</span>
+          <span>{formatCurrency(total)}</span>
+        </div>
+      </div>
+      <div className="mt-6 space-y-3">
+        <Button
+          type="submit"
+          form={formId}
+          size="lg"
+          className="w-full rounded-full bg-[linear-gradient(135deg,#F97316_0%,#F43F5E_100%)] text-white shadow-lg shadow-orange-500/25 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2"
+        >
+          {isSubmitting ? 'Processing…' : 'Pay now'}
+        </Button>
+        <div className="flex items-start gap-2 text-xs text-stone-500">
+          <ShieldCheck className="mt-0.5 h-4 w-4 text-amber-500" />
+          <span>Secure checkout • Your payment details are encrypted end-to-end.</span>
+        </div>
+      </div>
+    </div>
+  )
 
   React.useEffect(() => {
     if (deliveryZone === 'inside_dhaka') {
@@ -237,127 +387,172 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
-      {/* Order Summary */}
-      <div>
-        <h3 className="text-lg font-semibold mb-4">Order Summary</h3>
-        <div className="space-y-3">
-          {state.items.map((item) => (
-            <Card key={item.id} className="p-3">
-              <div className="flex items-center gap-3">
-                {item.image && (
-                  <div className="relative w-12 h-12 rounded-md overflow-hidden flex-shrink-0">
-                    <Image
-                      src={item.image.url}
-                      alt={item.image.alt || item.name}
-                      fill
-                      className="object-cover"
-                    />
-                  </div>
-                )}
-                <div className="flex-1">
-                  <h4 className="font-medium text-sm">{item.name}</h4>
-                  <Badge variant="secondary" className="text-xs">
-                    {item.category}
-                  </Badge>
-                  <p className="text-sm text-gray-600">
-                    {formatCurrency(item.price)} x {item.quantity}
-                  </p>
+    <div className="grid gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(320px,1fr)]">
+      <div className="space-y-8">
+        <form
+          id={formId}
+          onSubmit={handleSubmit}
+          className="space-y-8 rounded-[28px] border border-amber-100/70 bg-white/90 p-6 shadow-xl shadow-amber-200/40 backdrop-blur lg:p-10"
+        >
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-500">Step 02</p>
+            <h2 className="mt-2 text-2xl font-semibold text-stone-900 lg:text-3xl">Shipping information</h2>
+            <p className="mt-2 max-w-xl text-sm text-stone-500">
+              Provide your delivery details to complete this order.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded-full bg-amber-50/80 p-1 text-sm font-medium text-stone-600">
+            <button
+              type="button"
+              className="flex items-center gap-2 rounded-full bg-white px-4 py-2 text-amber-600 shadow-sm shadow-amber-100 ring-1 ring-amber-200"
+            >
+              <Truck className="h-4 w-4" />
+              Delivery
+            </button>
+            <button
+              type="button"
+              disabled
+              className="flex items-center gap-2 rounded-full px-4 py-2 text-stone-400 transition disabled:cursor-not-allowed"
+            >
+              <Store className="h-4 w-4" />
+              Pick up
+              <Badge className="rounded-full bg-white/85 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-stone-500">
+                Soon
+              </Badge>
+            </button>
+          </div>
+        </div>
+
+        {!user ? (
+          <div className="rounded-2xl border border-amber-100 bg-amber-50/70 p-5 text-sm text-amber-800 shadow-sm shadow-amber-200/40">
+            <p className="font-semibold">Guest checkout</p>
+            <p className="mt-2">
+              You can place an order without creating an account. Save your details for next time by{' '}
+              <Link className="font-semibold underline" href="/register">
+                creating an account
+              </Link>{' '}
+              or{' '}
+              <Link className="font-semibold underline" href="/login">
+                signing in
+              </Link>
+              .
+            </p>
+          </div>
+        ) : null}
+
+        <SectionCard
+          title="Contact details"
+          description="We’ll use this information to send updates about your order."
+        >
+          {!user ? (
+            <>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label htmlFor="firstName" className="text-sm font-medium text-stone-600">
+                    First name
+                  </label>
+                  <input
+                    id="firstName"
+                    type="text"
+                    value={firstName}
+                    onChange={(e) => setFirstName(e.target.value)}
+                    required
+                    className={inputClasses}
+                  />
                 </div>
-                <div className="text-right">
-                  <p className="font-semibold">{formatCurrency(item.price * item.quantity)}</p>
+                <div className="space-y-2">
+                  <label htmlFor="lastName" className="text-sm font-medium text-stone-600">
+                    Last name
+                  </label>
+                  <input
+                    id="lastName"
+                    type="text"
+                    value={lastName}
+                    onChange={(e) => setLastName(e.target.value)}
+                    required
+                    className={inputClasses}
+                  />
                 </div>
               </div>
-            </Card>
-          ))}
-        </div>
-        <div className="mt-4 space-y-2 text-sm">
-          <div className="flex items-center justify-between">
-            <span>Subtotal</span>
-            <span>{formatCurrency(subtotal)}</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span>
-              Delivery ({deliveryZone === 'outside_dhaka' ? 'Outside Dhaka' : 'Inside Dhaka'})
-            </span>
-            <span>{freeDelivery ? 'Free' : formatCurrency(shippingCharge)}</span>
-          </div>
-          <Separator />
-          <div className="flex items-center justify-between text-base font-semibold">
-            <span>Total</span>
-            <span>{formatCurrency(total)}</span>
-          </div>
-        </div>
-      </div>
-      {/* Customer Details (for guests) */}
-      {!user ? (
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold">Your details</h3>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="space-y-1">
-              <label htmlFor="firstName" className="text-sm font-medium">First name</label>
-              <input
-                id="firstName"
-                type="text"
-                value={firstName}
-                onChange={(e) => setFirstName(e.target.value)}
-                required
-                className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-              />
-            </div>
-            <div className="space-y-1">
-              <label htmlFor="lastName" className="text-sm font-medium">Last name</label>
-              <input
-                id="lastName"
-                type="text"
-                value={lastName}
-                onChange={(e) => setLastName(e.target.value)}
-                required
-                className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-              />
-            </div>
-          </div>
-          <div className="space-y-1">
-            <label htmlFor="email" className="text-sm font-medium">Email</label>
+              <div className="space-y-2">
+                <label htmlFor="email" className="text-sm font-medium text-stone-600">
+                  Email address
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  className={inputClasses}
+                />
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-stone-500">
+              We’ll send order updates to{' '}
+              <span className="font-medium text-stone-700">{user.email}</span>. Update the phone number below if you’d like us to
+              reach someone else for delivery.
+            </p>
+          )}
+          <div className="space-y-2">
+            <label htmlFor="customerNumber" className="text-sm font-medium text-stone-600">
+              Phone number
+            </label>
             <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              id="customerNumber"
+              name="customerNumber"
+              type="tel"
               required
-              className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
+              value={customerNumber}
+              onChange={(e) => setCustomerNumber(e.target.value)}
+              placeholder="e.g. +8801XXXXXXXXX"
+              className={inputClasses}
+            />
+            <p className="text-xs text-stone-500">We’ll use this number to coordinate your delivery.</p>
+          </div>
+          {user ? (
+            <p className="text-xs text-stone-400">
+              Order will be placed for {user.firstName} {user.lastName}.
+            </p>
+          ) : null}
+        </SectionCard>
+
+        <SectionCard
+          title="Shipping address"
+          description="Enter the address where you’d like your order delivered."
+        >
+          <div className="space-y-2">
+            <label htmlFor="address_line1" className="text-sm font-medium text-stone-600">
+              Address line 1
+            </label>
+            <input
+              id="address_line1"
+              value={address_line1}
+              onChange={(e) => setAddressLine1(e.target.value)}
+              required={!user}
+              placeholder="House, street, area"
+              className={inputClasses}
             />
           </div>
-        </div>
-      ) : null}
-
-      {/* Shipping Address */}
-      <div className="space-y-3">
-        <h3 className="text-lg font-semibold">Shipping address</h3>
-        <div className="space-y-1">
-          <label htmlFor="address_line1" className="text-sm font-medium">Address line 1</label>
-          <input
-            id="address_line1"
-            value={address_line1}
-            onChange={(e) => setAddressLine1(e.target.value)}
-            required={!user}
-            placeholder="House, street, area"
-            className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-          />
-        </div>
-        <div className="space-y-1">
-          <label htmlFor="address_line2" className="text-sm font-medium">Address line 2 (optional)</label>
-          <input
-            id="address_line2"
-            value={address_line2}
-            onChange={(e) => setAddressLine2(e.target.value)}
-            placeholder="Apartment, suite, etc."
-            className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-          />
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="space-y-1">
-              <label htmlFor="address_city" className="text-sm font-medium">City</label>
+          <div className="space-y-2">
+            <label htmlFor="address_line2" className="text-sm font-medium text-stone-600">
+              Address line 2 <span className="text-stone-400">(optional)</span>
+            </label>
+            <input
+              id="address_line2"
+              value={address_line2}
+              onChange={(e) => setAddressLine2(e.target.value)}
+              placeholder="Apartment, floor, landmark"
+              className={inputClasses}
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="address_city" className="text-sm font-medium text-stone-600">
+                City
+              </label>
               <input
                 id="address_city"
                 value={address_city}
@@ -366,266 +561,250 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
                 readOnly={isInsideDhaka}
                 aria-readonly={isInsideDhaka}
                 className={cn(
-                  'block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500',
-                  isInsideDhaka ? 'bg-gray-100 cursor-not-allowed text-gray-600' : '',
+                  inputClasses,
+                  isInsideDhaka ? 'cursor-not-allowed bg-stone-100 text-stone-600' : '',
                 )}
               />
               {isInsideDhaka ? (
-                <p className="text-xs text-gray-500">City is fixed to Dhaka for inside Dhaka delivery.</p>
+                <p className="text-xs text-stone-500">City is fixed to Dhaka for inside Dhaka delivery.</p>
               ) : null}
             </div>
-          <div className="space-y-1">
-            <label htmlFor="address_state" className="text-sm font-medium">State / Region</label>
-            <input
-              id="address_state"
-              value={address_state}
-              onChange={(e) => setAddressState(e.target.value)}
-              className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-            />
+            <div className="space-y-2">
+              <label htmlFor="address_state" className="text-sm font-medium text-stone-600">
+                State / region
+              </label>
+              <input
+                id="address_state"
+                value={address_state}
+                onChange={(e) => setAddressState(e.target.value)}
+                className={inputClasses}
+              />
+            </div>
           </div>
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div className="space-y-1">
-            <label htmlFor="address_postalCode" className="text-sm font-medium">Postal code</label>
-            <input
-              id="address_postalCode"
-              value={address_postalCode}
-              onChange={(e) => setAddressPostalCode(e.target.value)}
-              required={!user}
-              className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-            />
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="address_postalCode" className="text-sm font-medium text-stone-600">
+                Postal code
+              </label>
+              <input
+                id="address_postalCode"
+                value={address_postalCode}
+                onChange={(e) => setAddressPostalCode(e.target.value)}
+                required={!user}
+                className={inputClasses}
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="address_country" className="text-sm font-medium text-stone-600">
+                Country
+              </label>
+              <input
+                id="address_country"
+                value={address_country}
+                onChange={(e) => setAddressCountry(e.target.value)}
+                required={!user}
+                className={inputClasses}
+              />
+            </div>
           </div>
-          <div className="space-y-1">
-            <label htmlFor="address_country" className="text-sm font-medium">Country</label>
-            <input
-              id="address_country"
-              value={address_country}
-              onChange={(e) => setAddressCountry(e.target.value)}
-              required={!user}
-              className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-            />
-          </div>
-        </div>
-      </div>
+        </SectionCard>
 
-      {/* Delivery Zone */}
-      <div className="space-y-3">
-        <h3 className="text-lg font-semibold">Delivery area</h3>
-        <p className="text-sm text-gray-500">
-          Select where this order will be delivered so we can apply the correct delivery charge.
-        </p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <label
-            className={cn(
-              "border rounded-lg p-3 cursor-pointer transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500",
-              deliveryZone === 'inside_dhaka' ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200',
-            )}
-          >
-            <input
-              type="radio"
-              name="deliveryZone"
-              value="inside_dhaka"
-              checked={deliveryZone === 'inside_dhaka'}
-              onChange={() => {
-                setDeliveryZone('inside_dhaka')
-                setAddressCity('Dhaka')
-              }}
-              className="sr-only"
-            />
-            <div className="font-medium">Inside Dhaka</div>
-            <p className="text-sm text-gray-500">Delivery charge {formatCurrency(settings.insideDhakaCharge)}</p>
-          </label>
-          <label
-            className={cn(
-              "border rounded-lg p-3 cursor-pointer transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500",
-              deliveryZone === 'outside_dhaka' ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200',
-            )}
-          >
-            <input
-              type="radio"
-              name="deliveryZone"
-              value="outside_dhaka"
-              checked={deliveryZone === 'outside_dhaka'}
-              onChange={() => {
-                setDeliveryZone('outside_dhaka')
-                if (address_city === 'Dhaka') {
-                  setAddressCity('')
-                }
-              }}
-              className="sr-only"
-            />
-            <div className="font-medium">Outside Dhaka</div>
-            <p className="text-sm text-gray-500">Delivery charge {formatCurrency(settings.outsideDhakaCharge)}</p>
-          </label>
-        </div>
-        {freeDelivery ? (
-          <p className="text-sm text-green-600 font-semibold">Free delivery applied for this order.</p>
-        ) : (
-          <p className="text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
-            Free delivery applies automatically when your subtotal reaches {formatCurrency(settings.freeDeliveryThreshold)}.
-          </p>
-        )}
-        {!freeDelivery && isDigitalPayment ? (
-          <p className="text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
-            A flat delivery charge of {formatCurrency(settings.digitalPaymentDeliveryCharge)} applies to digital wallet payments.
-          </p>
-        ) : (
-          <p className="text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
-            Digital wallet payments below {formatCurrency(settings.freeDeliveryThreshold)} have a flat delivery charge of{' '}
-            {formatCurrency(settings.digitalPaymentDeliveryCharge)}.
-          </p>
-        )}
-      </div>
-
-      {/* Payment Method */}
-      <div className="space-y-3">
-        <h3 className="text-lg font-semibold">Payment method</h3>
-        <p className="text-sm text-gray-500">
-          Choose how you would like to pay. Digital wallet payments require a completed transfer before placing the order.
-        </p>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          {PAYMENT_OPTIONS.map((option) => (
+        <SectionCard
+          title="Delivery preferences"
+          description="Select the delivery zone so we can calculate the correct shipping fee."
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
             <label
-              key={option.value}
               className={cn(
-                'border rounded-lg p-3 cursor-pointer transition flex flex-col items-center gap-2 text-center focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500',
-                paymentMethod === option.value ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200',
+                'flex cursor-pointer flex-col gap-2 rounded-2xl border border-stone-200 bg-white/85 p-4 shadow-sm transition hover:border-amber-200 hover:shadow-amber-100 focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-0',
+                deliveryZone === 'inside_dhaka' ? 'border-amber-400 shadow-amber-100 ring-2 ring-amber-200/80' : '',
               )}
             >
               <input
                 type="radio"
-                name="paymentMethod"
-                value={option.value}
-                checked={paymentMethod === option.value}
+                name="deliveryZone"
+                value="inside_dhaka"
+                checked={deliveryZone === 'inside_dhaka'}
                 onChange={() => {
-                  setPaymentMethod(option.value)
-                  if (option.value === 'cod') {
-                    setPaymentSenderNumber('')
-                    setPaymentTransactionId('')
-                  }
-                  setError(null)
+                  setDeliveryZone('inside_dhaka')
+                  setAddressCity('Dhaka')
                 }}
                 className="sr-only"
               />
-              <div className="relative w-32 h-16">
-                <Image
-                  src={option.logo.src}
-                  alt={option.logo.alt}
-                  width={option.logo.width}
-                  height={option.logo.height}
-                  className="h-full w-full object-contain"
-                  sizes="128px"
-                  priority={option.value === 'cod'}
-                />
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-semibold text-stone-900">Inside Dhaka</span>
+                {deliveryZone === 'inside_dhaka' ? (
+                  <Badge className="rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">Selected</Badge>
+                ) : null}
               </div>
-              <span className="font-medium text-sm">{option.label}</span>
+              <p className="text-xs text-stone-500">
+                Delivery charge {formatCurrency(settings.insideDhakaCharge)}
+              </p>
             </label>
-          ))}
-        </div>
-
-        {requiresDigitalPaymentDetails ? (
-          <div className="space-y-4">
-            {digitalPaymentInstructions?.length ? (
-              <Alert className="bg-blue-50 border-blue-200 text-blue-900">
-                <AlertDescription>
-                  <ul className="list-disc list-inside space-y-1">
-                    {digitalPaymentInstructions.map((instruction, index) => (
-                      <li key={index}>{instruction}</li>
-                    ))}
-                    <li>
-                      Delivery charge is {formatCurrency(settings.digitalPaymentDeliveryCharge)} for digital wallet payments when
-                      the subtotal is below {formatCurrency(settings.freeDeliveryThreshold)}.
-                    </li>
-                  </ul>
-                </AlertDescription>
-              </Alert>
-            ) : null}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <label htmlFor="paymentSenderNumber" className="text-sm font-medium text-gray-700">
-                  Sender wallet number
-                </label>
-                <input
-                  id="paymentSenderNumber"
-                  name="paymentSenderNumber"
-                  type="tel"
-                  value={paymentSenderNumber}
-                  onChange={(e) => {
-                    setPaymentSenderNumber(e.target.value)
-                    setError(null)
-                  }}
-                  required={requiresDigitalPaymentDetails}
-                  placeholder="e.g. 01XXXXXXXXX"
-                  className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-                />
+            <label
+              className={cn(
+                'flex cursor-pointer flex-col gap-2 rounded-2xl border border-stone-200 bg-white/85 p-4 shadow-sm transition hover:border-amber-200 hover:shadow-amber-100 focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-0',
+                deliveryZone === 'outside_dhaka' ? 'border-amber-400 shadow-amber-100 ring-2 ring-amber-200/80' : '',
+              )}
+            >
+              <input
+                type="radio"
+                name="deliveryZone"
+                value="outside_dhaka"
+                checked={deliveryZone === 'outside_dhaka'}
+                onChange={() => {
+                  setDeliveryZone('outside_dhaka')
+                  if (address_city === 'Dhaka') {
+                    setAddressCity('')
+                  }
+                }}
+                className="sr-only"
+              />
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-semibold text-stone-900">Outside Dhaka</span>
+                {deliveryZone === 'outside_dhaka' ? (
+                  <Badge className="rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">Selected</Badge>
+                ) : null}
               </div>
-              <div className="space-y-2">
-                <label htmlFor="paymentTransactionId" className="text-sm font-medium text-gray-700">
-                  Transaction ID
-                </label>
+              <p className="text-xs text-stone-500">
+                Delivery charge {formatCurrency(settings.outsideDhakaCharge)}
+              </p>
+            </label>
+          </div>
+          <div className="grid gap-3">
+            {freeDelivery ? (
+              <div className="flex items-center gap-2 rounded-xl border border-emerald-100 bg-emerald-50/80 px-4 py-3 text-sm font-semibold text-emerald-700 shadow-sm">
+                <Truck className="h-4 w-4" />
+                Free delivery is applied to this order.
+              </div>
+            ) : (
+              <div className="rounded-xl border border-amber-100 bg-amber-50/80 px-4 py-3 text-xs font-medium text-amber-700 shadow-sm">
+                Spend {formatCurrency(settings.freeDeliveryThreshold)} to unlock complimentary delivery.
+              </div>
+            )}
+          </div>
+        </SectionCard>
+
+        {error ? (
+          <Alert variant="destructive" className="rounded-2xl border border-red-200 bg-red-50/70 text-red-800">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : null}
+
+          <OrderSummaryCard className="lg:hidden" layout="mobile" />
+        </form>
+        <SectionCard
+          title="Payment method"
+          description="Choose how you would like to pay for this order."
+          className="rounded-[26px] border-amber-100/80 bg-white/90 shadow-xl shadow-amber-200/60 backdrop-blur-sm"
+        >
+          <div className="rounded-2xl border border-amber-200/70 bg-amber-50/80 p-4 text-sm font-medium text-amber-900 shadow-sm shadow-amber-100">
+            Digital wallet payments have a flat delivery charge of{' '}
+            <span className="font-semibold">{formatCurrency(settings.digitalPaymentDeliveryCharge)}</span> when the subtotal is
+            below <span className="font-semibold">{formatCurrency(settings.freeDeliveryThreshold)}</span>.
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {PAYMENT_OPTIONS.map((option) => (
+              <label
+                key={option.value}
+                className={cn(
+                  'group flex cursor-pointer flex-col items-center gap-3 rounded-2xl border border-stone-200 bg-white/85 p-4 text-center shadow-sm transition hover:border-amber-200 hover:shadow-amber-100 focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-0',
+                  paymentMethod === option.value ? 'border-amber-400 shadow-amber-100 ring-2 ring-amber-200/80' : '',
+                )}
+              >
                 <input
-                  id="paymentTransactionId"
-                  name="paymentTransactionId"
-                  type="text"
-                  value={paymentTransactionId}
-                  onChange={(e) => {
-                    setPaymentTransactionId(e.target.value)
+                  type="radio"
+                  name="paymentMethod"
+                  value={option.value}
+                  checked={paymentMethod === option.value}
+                  onChange={() => {
+                    setPaymentMethod(option.value)
+                    if (option.value === 'cod') {
+                      setPaymentSenderNumber('')
+                      setPaymentTransactionId('')
+                    }
                     setError(null)
                   }}
-                  required={requiresDigitalPaymentDetails}
-                  placeholder="e.g. TXN123456789"
-                  className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
+                  className="sr-only"
+                  form={formId}
                 />
+                <div className="relative h-16 w-32">
+                  <Image
+                    src={option.logo.src}
+                    alt={option.logo.alt}
+                    width={option.logo.width}
+                    height={option.logo.height}
+                    className="h-full w-full object-contain"
+                    sizes="128px"
+                    priority={option.value === 'cod'}
+                  />
+                </div>
+                <span className="text-sm font-medium text-stone-700">{option.label}</span>
+              </label>
+            ))}
+          </div>
+          {requiresDigitalPaymentDetails ? (
+            <div className="space-y-5 rounded-2xl border border-amber-100 bg-amber-50/70 p-5 text-amber-900 shadow-sm shadow-amber-100">
+              {digitalPaymentInstructions?.length ? (
+                <Alert className="border-transparent bg-transparent p-0 text-amber-900">
+                  <AlertDescription>
+                    <ul className="list-disc space-y-1 pl-5 text-sm">
+                      {digitalPaymentInstructions.map((instruction, index) => (
+                        <li key={index}>{instruction}</li>
+                      ))}
+                    </ul>
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label htmlFor="paymentSenderNumber" className="text-sm font-medium text-stone-600">
+                    Sender wallet number
+                  </label>
+                  <input
+                    id="paymentSenderNumber"
+                    name="paymentSenderNumber"
+                    type="tel"
+                    value={paymentSenderNumber}
+                    onChange={(e) => {
+                      setPaymentSenderNumber(e.target.value)
+                      setError(null)
+                    }}
+                    required={requiresDigitalPaymentDetails}
+                    placeholder="e.g. 01XXXXXXXXX"
+                    className={inputClasses}
+                    form={formId}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="paymentTransactionId" className="text-sm font-medium text-stone-600">
+                    Transaction ID
+                  </label>
+                  <input
+                    id="paymentTransactionId"
+                    name="paymentTransactionId"
+                    type="text"
+                    value={paymentTransactionId}
+                    onChange={(e) => {
+                      setPaymentTransactionId(e.target.value)
+                      setError(null)
+                    }}
+                    required={requiresDigitalPaymentDetails}
+                    placeholder="e.g. TXN123456789"
+                    className={inputClasses}
+                    form={formId}
+                  />
+                </div>
               </div>
             </div>
-          </div>
-        ) : (
-          <p className="text-xs text-gray-500">
-            You can pay in cash when the delivery arrives.
-          </p>
-        )}
+          ) : (
+            <p className="text-xs text-stone-500">Pay with cash when your delivery arrives.</p>
+          )}
+        </SectionCard>
       </div>
-
-      {/* Error Message */}
-      {error && (
-        <Alert variant="destructive">
-          <AlertDescription>{error}</AlertDescription>
-        </Alert>
-      )}
-
-      {/* Customer Number */}
-      <div className="space-y-2">
-        <label htmlFor="customerNumber" className="text-sm font-medium text-gray-700">
-          Customer number
-        </label>
-        <input
-          id="customerNumber"
-          name="customerNumber"
-          type="tel"
-          required
-          value={customerNumber}
-          onChange={(e) => setCustomerNumber(e.target.value)}
-          placeholder="e.g. +1 555 123 4567"
-          className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-        />
-        <p className="text-xs text-gray-500">We will use this to contact you about your order.</p>
+      <div className="space-y-6">
+        <OrderSummaryCard className="hidden lg:block" layout="desktop" />
       </div>
-
-      {/* Submit Button */}
-      <div className="pt-4">
-        <Button type="submit" disabled={isSubmitting} className="w-full" size="lg">
-          {isSubmitting ? 'Placing Order...' : 'Place Order'}
-        </Button>
-      </div>
-
-      {user ? (
-        <div className="text-sm text-gray-500 text-center">
-          <p>
-            Order will be placed for: {user.firstName} {user.lastName}
-          </p>
-          <p>Email: {user.email}</p>
-        </div>
-      ) : null}
-    </form>
+    </div>
   )
 }

--- a/src/app/(frontend)/checkout/page.tsx
+++ b/src/app/(frontend)/checkout/page.tsx
@@ -7,8 +7,8 @@ import config from '@/payload.config'
 import { CheckoutForm } from './checkout-form'
 import { normalizeDeliverySettings, DEFAULT_DELIVERY_SETTINGS } from '@/lib/delivery-settings'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { SiteHeader } from '@/components/site-header'
+import { Check } from 'lucide-react'
 
 export const dynamic = 'force-dynamic'
 
@@ -26,35 +26,53 @@ export default async function CheckoutPage() {
   const deliverySettings = normalizeDeliverySettings((deliverySettingsResult as any)?.docs?.[0] || DEFAULT_DELIVERY_SETTINGS)
 
 
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <SiteHeader variant="full" user={(fullUser as any) || (user as any)} />
-      <div className="container mx-auto px-4 py-8">
-        <Button asChild variant="ghost" className="mb-6">
-          <Link href="/">← Back to Shopping</Link>
-        </Button>
+  const steps = [
+    { label: 'Cart', status: 'done' as const },
+    { label: 'Checkout', status: 'current' as const },
+  ]
 
-        <div className="max-w-2xl mx-auto">
-          {!user ? (
-            <div className="mb-6 rounded-md border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800">
-              <p className="font-medium">Guest checkout</p>
-              <p className="mt-1">
-                You can place an order without an account. We’ll just need your contact and shipping details.
-                Want faster checkout next time?{' '}
-                <Link className="underline font-medium" href="/register">Create an account</Link>{' '}
-                or <Link className="underline font-medium" href="/login">sign in</Link>.
-              </p>
-            </div>
-          ) : null}
-          <Card>
-            <CardHeader>
-              <CardTitle>Checkout</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <CheckoutForm user={(fullUser as any) || (user as any)} deliverySettings={deliverySettings} />
-            </CardContent>
-          </Card>
+  return (
+    <div className="relative min-h-screen bg-gradient-to-br from-gray-50 via-white to-stone-100">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(80%_80%_at_50%_0%,rgba(251,191,36,0.14),transparent)]" />
+      <SiteHeader variant="full" user={(fullUser as any) || (user as any)} />
+      <div className="relative mx-auto w-full max-w-6xl px-4 pb-16 pt-10 lg:px-8 lg:pt-16">
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          <Button
+            asChild
+            variant="ghost"
+            className="h-11 rounded-full border border-transparent bg-white/80 px-4 text-sm font-semibold text-stone-600 shadow-sm backdrop-blur transition hover:border-amber-200 hover:bg-white hover:text-amber-600"
+          >
+            <Link href="/">← Back to shopping</Link>
+          </Button>
+          <div className="flex flex-wrap items-center gap-3 text-sm font-medium text-stone-500">
+            {steps.map((step, index) => (
+              <React.Fragment key={step.label}>
+                <span
+                  className={
+                    step.status === 'current'
+                      ? 'flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-amber-600'
+                      : 'flex items-center gap-2 text-stone-500'
+                  }
+                >
+                  <span
+                    className={
+                      step.status === 'done'
+                        ? 'flex size-6 items-center justify-center rounded-full bg-gradient-to-r from-amber-500 to-rose-500 text-xs font-semibold text-white shadow'
+                        : 'flex size-6 items-center justify-center rounded-full border border-amber-200 bg-white text-xs font-semibold text-amber-600 shadow-sm'
+                    }
+                    aria-hidden
+                  >
+                    {step.status === 'done' ? <Check className="h-3 w-3" /> : index + 1}
+                  </span>
+                  {step.label}
+                </span>
+                {index < steps.length - 1 ? <span className="hidden h-px w-8 bg-stone-300 sm:block" aria-hidden /> : null}
+              </React.Fragment>
+            ))}
+          </div>
         </div>
+
+        <CheckoutForm user={(fullUser as any) || (user as any)} deliverySettings={deliverySettings} />
       </div>
     </div>
   )

--- a/src/app/(frontend)/order/[id]/order-form.tsx
+++ b/src/app/(frontend)/order/[id]/order-form.tsx
@@ -3,10 +3,11 @@
 import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
+import { Minus, Plus, ShieldCheck, Truck } from 'lucide-react'
+
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Separator } from '@/components/ui/separator'
+import { Badge } from '@/components/ui/badge'
 import type { DeliverySettings } from '@/lib/delivery-settings'
 import { DEFAULT_DELIVERY_SETTINGS } from '@/lib/delivery-settings'
 import { cn } from '@/lib/utils'
@@ -60,6 +61,164 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
   const requiresDigitalPaymentDetails = isDigitalPayment
   const digitalPaymentInstructions = DIGITAL_PAYMENT_INSTRUCTIONS[paymentMethod]
 
+  const labelClasses = 'text-sm font-medium text-stone-700'
+  const inputClasses =
+    'block w-full rounded-xl border border-stone-200 bg-white/85 px-4 py-2.5 text-sm text-stone-700 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-amber-400/70 focus:ring-offset-0'
+
+  const SectionCard = ({
+    title,
+    description,
+    children,
+    className,
+  }: {
+    title: string
+    description?: string
+    children: React.ReactNode
+    className?: string
+  }) => (
+    <div className={cn('rounded-3xl border border-amber-100/70 bg-white/85 p-6 shadow-sm shadow-amber-200/40', className)}>
+      <div className="space-y-1">
+        <h3 className="text-lg font-semibold text-stone-900">{title}</h3>
+        {description ? <p className="text-sm text-stone-500">{description}</p> : null}
+      </div>
+      <div className="mt-5 space-y-5">{children}</div>
+    </div>
+  )
+
+  const ProductOverviewCard = () => (
+    <div className="rounded-[26px] border border-amber-100/80 bg-white/90 p-6 shadow-xl shadow-amber-200/50">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-amber-500">Product overview</p>
+          <h2 className="text-2xl font-semibold text-stone-900">{item.name}</h2>
+          <p className="text-sm text-stone-500">Review the product details before confirming your order.</p>
+        </div>
+        {typeof (item as any).category === 'object' || (item as any).category ? (
+          <Badge className="ml-auto h-7 rounded-full bg-amber-100 px-3 text-xs font-medium text-amber-700">
+            {typeof (item as any).category === 'object'
+              ? ((item as any).category as any)?.name
+              : (item as any).category}
+          </Badge>
+        ) : null}
+      </div>
+      {item.image && typeof item.image === 'object' && item.image.url ? (
+        <div className="relative mt-6 h-56 overflow-hidden rounded-3xl border border-amber-100 bg-amber-50">
+          <Image
+            src={item.image.url}
+            alt={item.image.alt || item.name}
+            fill
+            className="object-cover"
+            sizes="(min-width: 1024px) 384px, 100vw"
+          />
+        </div>
+      ) : null}
+      <div className="mt-6 space-y-3 text-sm text-stone-600">
+        {item.shortDescription || item.description ? (
+          <p className="text-base text-stone-600">
+            {(item.shortDescription as string) || (item.description as string)}
+          </p>
+        ) : null}
+        <div className="flex items-center justify-between rounded-2xl bg-gradient-to-r from-amber-50 to-rose-50 px-4 py-3 text-sm text-amber-700">
+          <span className="font-medium">Unit price</span>
+          <span className="text-base font-semibold text-rose-600">৳{Number(item.price).toFixed(2)}</span>
+        </div>
+      </div>
+    </div>
+  )
+
+  const SummaryPanel = ({ layout }: { layout: 'mobile' | 'desktop' }) => (
+    <div
+      className={cn(
+        'rounded-[26px] border border-amber-100/80 bg-white/90 p-6 shadow-xl shadow-amber-200/50',
+        layout === 'mobile' ? 'lg:hidden' : 'hidden lg:block',
+      )}
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-stone-900">Review your cart</h3>
+          <p className="text-sm text-stone-500">Confirm the quantity and totals before placing your order.</p>
+        </div>
+        <Badge className="ml-auto h-7 rounded-full bg-amber-100 px-3 text-xs font-medium text-amber-700">Secure checkout</Badge>
+      </div>
+
+      <div className="mt-5 flex flex-col gap-4 rounded-3xl border border-amber-50 bg-white/75 p-4 shadow-inner shadow-amber-200/40 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1 text-sm text-stone-600">
+          <p className="text-sm font-semibold text-stone-900">Quantity</p>
+          <p>Adjust how many units you would like to order.</p>
+        </div>
+        <div className="flex items-center gap-3 rounded-full border border-stone-200 bg-white/85 px-2 py-1 shadow-sm">
+          <button
+            type="button"
+            onClick={() => setQuantity(Math.max(1, quantity - 1))}
+            disabled={quantity <= 1}
+            aria-label="Decrease quantity"
+            className="flex h-9 w-9 items-center justify-center rounded-full text-stone-500 transition hover:bg-amber-50 hover:text-amber-600 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white"
+          >
+            <Minus className="h-4 w-4" />
+          </button>
+          <span className="min-w-[2ch] text-base font-semibold text-stone-900">{quantity}</span>
+          <button
+            type="button"
+            onClick={() => setQuantity(quantity + 1)}
+            aria-label="Increase quantity"
+            className="flex h-9 w-9 items-center justify-center rounded-full text-stone-500 transition hover:bg-amber-50 hover:text-amber-600"
+          >
+            <Plus className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-5 space-y-3 rounded-3xl border border-amber-50 bg-white/75 p-5 shadow-inner shadow-amber-200/40">
+        <div className="flex items-center justify-between text-sm text-stone-600">
+          <span>Subtotal</span>
+          <span className="font-medium text-stone-900">{formatCurrency(subtotal)}</span>
+        </div>
+        <div className="flex items-center justify-between text-sm text-stone-600">
+          <span>Delivery {deliveryZone === 'outside_dhaka' ? '(Outside Dhaka)' : '(Inside Dhaka)'}</span>
+          <span className="font-medium text-stone-900">{freeDelivery ? 'Free' : formatCurrency(shippingCharge)}</span>
+        </div>
+        <div className="flex items-center justify-between text-base font-semibold text-stone-900">
+          <span>Total due</span>
+          <span>{formatCurrency(total)}</span>
+        </div>
+        {freeDelivery ? (
+          <p className="text-xs font-semibold text-emerald-600">Congratulations! Free delivery is applied to this order.</p>
+        ) : (
+          <p className="text-xs text-stone-500">
+            Spend {formatCurrency(settings.freeDeliveryThreshold)} to unlock complimentary delivery.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+
+  const NeedHelpCard = () => (
+    <div className="rounded-3xl border border-amber-100/70 bg-gradient-to-br from-amber-50 via-white to-rose-50 p-6 text-sm text-stone-700 shadow-lg shadow-amber-200/50">
+      <h3 className="text-base font-semibold text-stone-900">Need help?</h3>
+      <p className="mt-2 leading-relaxed">
+        Give us a call or send us a message if you have any questions about this product or your order. Our friendly team is ready
+        to talk over the phone or chat on your favourite messaging app.
+      </p>
+      <div className="mt-4 flex flex-col gap-2 text-sm font-semibold text-amber-700">
+        <a
+          href="tel:01639590392"
+          className="flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-amber-700 shadow-sm transition hover:bg-amber-100"
+        >
+          <span aria-hidden>📞</span>
+          Call us: 01639-590392
+        </a>
+        <a
+          href="https://www.m.me/onlinebazarbarguna"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 rounded-full bg-[#0084FF] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#0073E6]"
+        >
+          <span aria-hidden>💬</span>
+          Message us on Messenger
+        </a>
+      </div>
+    </div>
+  )
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -100,7 +259,6 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
           paymentTransactionId: requiresDigitalPaymentDetails ? paymentTransactionId.trim() : undefined,
           ...(user
             ? {
-                // Optional override shipping
                 shippingAddress:
                   address_line1 || address_city || address_postalCode || address_country
                     ? {
@@ -114,7 +272,6 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
                     : undefined,
               }
             : {
-                // Guest checkout details
                 customerName: `${firstName} ${lastName}`.trim(),
                 customerEmail: email,
                 shippingAddress: {
@@ -132,7 +289,6 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
       if (response.ok) {
         const data = await response.json().catch(() => null)
         const oid = (data as any)?.doc?.id
-        // Save confirmation preview for guest page
         try {
           sessionStorage.setItem(
             'last-order-preview',
@@ -172,306 +328,381 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="space-y-3">
-        <label htmlFor="quantity" className="text-sm font-medium">
-          Quantity:
-        </label>
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            onClick={() => setQuantity(Math.max(1, quantity - 1))}
-            disabled={quantity <= 1}
-            variant="outline"
-            size="sm"
-          >
-            -
-          </Button>
-          <Input
-            type="number"
-            id="quantity"
-            value={quantity}
-            onChange={(e) => setQuantity(Math.max(1, parseInt(e.target.value) || 1))}
-            min="1"
-            className="w-20 text-center"
-          />
-          <Button
-            type="button"
-            onClick={() => setQuantity(quantity + 1)}
-            variant="outline"
-            size="sm"
-          >
-            +
-          </Button>
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <label htmlFor="customerNumber" className="text-sm font-medium">
-          Customer number
-        </label>
-        <Input
-          id="customerNumber"
-          value={customerNumber}
-          onChange={(e) => setCustomerNumber(e.target.value)}
-          placeholder="e.g. 01XXXXXXXXX"
-          required
-        />
-      </div>
-
-      {/* Customer Details (for guests) */}
-      {!user ? (
-        <div className="space-y-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <label htmlFor="firstName" className="text-sm font-medium">First name</label>
-              <Input id="firstName" value={firstName} onChange={(e) => setFirstName(e.target.value)} required />
+    <div className="grid gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(320px,1fr)]">
+      <div className="space-y-8">
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-8 rounded-[28px] border border-amber-100/70 bg-white/90 p-6 shadow-xl shadow-amber-200/40 backdrop-blur lg:p-10"
+        >
+          {!user ? (
+            <div className="rounded-3xl border border-amber-100 bg-amber-50/70 p-5 text-sm text-amber-800 shadow-sm shadow-amber-200/40">
+              <p className="font-semibold">Guest checkout</p>
+              <p className="mt-1 leading-relaxed">
+                You can order this item without creating an account. Provide your contact and delivery details below or{' '}
+                <a href="/login" className="font-semibold underline">
+                  sign in
+                </a>{' '}
+                to autofill your saved information.
+              </p>
             </div>
-            <div className="space-y-2">
-              <label htmlFor="lastName" className="text-sm font-medium">Last name</label>
-              <Input id="lastName" value={lastName} onChange={(e) => setLastName(e.target.value)} required />
-            </div>
-          </div>
-          <div className="space-y-2">
-            <label htmlFor="email" className="text-sm font-medium">Email</label>
-            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-          </div>
-        </div>
-      ) : null}
+          ) : null}
 
-      {/* Shipping Address */}
-      <div className="space-y-3">
-        <h3 className="text-lg font-semibold">Shipping address</h3>
-        <div className="space-y-2">
-          <label htmlFor="address_line1" className="text-sm font-medium">Address line 1</label>
-          <Input id="address_line1" value={address_line1} onChange={(e) => setAddressLine1(e.target.value)} required={!user} />
-        </div>
-        <div className="space-y-2">
-          <label htmlFor="address_line2" className="text-sm font-medium">Address line 2 (optional)</label>
-          <Input id="address_line2" value={address_line2} onChange={(e) => setAddressLine2(e.target.value)} />
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <label htmlFor="address_city" className="text-sm font-medium">City</label>
-            <Input id="address_city" value={address_city} onChange={(e) => setAddressCity(e.target.value)} required={!user} />
-          </div>
-          <div className="space-y-2">
-            <label htmlFor="address_state" className="text-sm font-medium">State / Region</label>
-            <Input id="address_state" value={address_state} onChange={(e) => setAddressState(e.target.value)} />
-          </div>
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <label htmlFor="address_postalCode" className="text-sm font-medium">Postal code</label>
-            <Input id="address_postalCode" value={address_postalCode} onChange={(e) => setAddressPostalCode(e.target.value)} required={!user} />
-          </div>
-          <div className="space-y-2">
-            <label htmlFor="address_country" className="text-sm font-medium">Country</label>
-            <Input id="address_country" value={address_country} onChange={(e) => setAddressCountry(e.target.value)} required={!user} />
-          </div>
-        </div>
-      </div>
-
-      {/* Delivery Zone */}
-      <div className="space-y-3">
-        <h3 className="text-lg font-semibold">Delivery area</h3>
-        <p className="text-sm text-gray-500">
-          Choose whether this address is inside or outside Dhaka to calculate delivery charges.
-        </p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <label
-            className={cn(
-              'border rounded-lg p-3 cursor-pointer transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500',
-              deliveryZone === 'inside_dhaka' ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200',
-            )}
-          >
-            <input
-              type="radio"
-              name="deliveryZone"
-              value="inside_dhaka"
-              checked={deliveryZone === 'inside_dhaka'}
-              onChange={() => setDeliveryZone('inside_dhaka')}
-              className="sr-only"
-            />
-            <div className="font-medium">Inside Dhaka</div>
-            <p className="text-sm text-gray-500">Delivery charge {formatCurrency(settings.insideDhakaCharge)}</p>
-          </label>
-          <label
-            className={cn(
-              'border rounded-lg p-3 cursor-pointer transition focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500',
-              deliveryZone === 'outside_dhaka' ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200',
-            )}
-          >
-            <input
-              type="radio"
-              name="deliveryZone"
-              value="outside_dhaka"
-              checked={deliveryZone === 'outside_dhaka'}
-              onChange={() => setDeliveryZone('outside_dhaka')}
-              className="sr-only"
-            />
-            <div className="font-medium">Outside Dhaka</div>
-            <p className="text-sm text-gray-500">Delivery charge {formatCurrency(settings.outsideDhakaCharge)}</p>
-          </label>
-        </div>
-        {freeDelivery ? (
-          <p className="text-sm text-green-600 font-semibold">Free delivery applied for this order.</p>
-        ) : (
-          <p className="text-xs text-gray-500">
-            Free delivery applies automatically when your subtotal reaches {formatCurrency(settings.freeDeliveryThreshold)}.
-          </p>
-        )}
-        {!freeDelivery && isDigitalPayment ? (
-          <p className="text-xs text-gray-500">
-            A flat delivery charge of {formatCurrency(settings.digitalPaymentDeliveryCharge)} applies to digital wallet payments.
-          </p>
-        ) : (
-          <p className="text-xs text-gray-500">
-            Digital wallet payments below {formatCurrency(settings.freeDeliveryThreshold)} have a flat delivery charge of{' '}
-            {formatCurrency(settings.digitalPaymentDeliveryCharge)}.
-          </p>
-        )}
-      </div>
-
-      {/* Payment Method */}
-      <div className="space-y-3">
-        <h3 className="text-lg font-semibold">Payment method</h3>
-        <p className="text-sm text-gray-500">
-          Choose how you would like to pay. Digital wallet payments require a completed transfer before placing the order.
-        </p>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          {PAYMENT_OPTIONS.map((option) => (
-            <label
-              key={option.value}
-              className={cn(
-                'border rounded-lg p-3 cursor-pointer transition flex flex-col items-center gap-2 text-center focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500',
-                paymentMethod === option.value ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200',
-              )}
-            >
-              <input
-                type="radio"
-                name="paymentMethod"
-                value={option.value}
-                checked={paymentMethod === option.value}
-                onChange={() => {
-                  setPaymentMethod(option.value)
-                  if (option.value === 'cod') {
-                    setPaymentSenderNumber('')
-                    setPaymentTransactionId('')
-                  }
-                  setError('')
-                }}
-                className="sr-only"
-              />
-              <div className="relative w-32 h-16">
-                <Image
-                  src={option.logo.src}
-                  alt={option.logo.alt}
-                  width={option.logo.width}
-                  height={option.logo.height}
-                  className="h-full w-full object-contain"
-                  sizes="128px"
-                  priority={option.value === 'cod'}
-                />
-              </div>
-              <span className="font-medium text-sm">{option.label}</span>
-            </label>
-          ))}
-        </div>
-
-        {requiresDigitalPaymentDetails ? (
-          <div className="space-y-4">
-            {digitalPaymentInstructions?.length ? (
-              <Alert className="bg-blue-50 border-blue-200 text-blue-900">
-                <AlertDescription>
-                  <ul className="list-disc list-inside space-y-1">
-                    {digitalPaymentInstructions.map((instruction, index) => (
-                      <li key={index}>{instruction}</li>
-                    ))}
-                    <li>
-                      Delivery charge is {formatCurrency(settings.digitalPaymentDeliveryCharge)} for digital wallet payments when
-                      the subtotal is below {formatCurrency(settings.freeDeliveryThreshold)}.
-                    </li>
-                  </ul>
-                </AlertDescription>
-              </Alert>
-            ) : null}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <SectionCard title="Contact information" description="We’ll use this to share order updates and delivery details.">
+            <div className="space-y-4">
               <div className="space-y-2">
-                <label htmlFor="paymentSenderNumber" className="text-sm font-medium text-gray-700">
-                  Sender wallet number
+                <label htmlFor="customerNumber" className={labelClasses}>
+                  Customer number
                 </label>
-                <Input
-                  id="paymentSenderNumber"
-                  name="paymentSenderNumber"
-                  type="tel"
-                  value={paymentSenderNumber}
-                  onChange={(e) => {
-                    setPaymentSenderNumber(e.target.value)
-                    setError('')
-                  }}
-                  required={requiresDigitalPaymentDetails}
+                <input
+                  id="customerNumber"
+                  name="customerNumber"
+                  value={customerNumber}
+                  onChange={(e) => setCustomerNumber(e.target.value)}
                   placeholder="e.g. 01XXXXXXXXX"
+                  required
+                  className={inputClasses}
+                />
+              </div>
+
+              {!user ? (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <label htmlFor="firstName" className={labelClasses}>
+                      First name
+                    </label>
+                    <input
+                      id="firstName"
+                      name="firstName"
+                      value={firstName}
+                      onChange={(e) => setFirstName(e.target.value)}
+                      required
+                      className={inputClasses}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="lastName" className={labelClasses}>
+                      Last name
+                    </label>
+                    <input
+                      id="lastName"
+                      name="lastName"
+                      value={lastName}
+                      onChange={(e) => setLastName(e.target.value)}
+                      required
+                      className={inputClasses}
+                    />
+                  </div>
+                  <div className="space-y-2 sm:col-span-2">
+                    <label htmlFor="email" className={labelClasses}>
+                      Email
+                    </label>
+                    <input
+                      id="email"
+                      name="email"
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      required
+                      className={inputClasses}
+                    />
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </SectionCard>
+
+          <SectionCard
+            title="Delivery address"
+            description="Tell us where to deliver your order so we can estimate shipping charges."
+          >
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <label htmlFor="address_line1" className={labelClasses}>
+                  Address line 1
+                </label>
+                <input
+                  id="address_line1"
+                  name="address_line1"
+                  value={address_line1}
+                  onChange={(e) => setAddressLine1(e.target.value)}
+                  required={!user}
+                  className={inputClasses}
                 />
               </div>
               <div className="space-y-2">
-                <label htmlFor="paymentTransactionId" className="text-sm font-medium text-gray-700">
-                  Transaction ID
+                <label htmlFor="address_line2" className={labelClasses}>
+                  Address line 2 (optional)
                 </label>
-                <Input
-                  id="paymentTransactionId"
-                  name="paymentTransactionId"
-                  type="text"
-                  value={paymentTransactionId}
-                  onChange={(e) => {
-                    setPaymentTransactionId(e.target.value)
-                    setError('')
-                  }}
-                  required={requiresDigitalPaymentDetails}
-                  placeholder="e.g. TXN123456789"
+                <input
+                  id="address_line2"
+                  name="address_line2"
+                  value={address_line2}
+                  onChange={(e) => setAddressLine2(e.target.value)}
+                  className={inputClasses}
                 />
               </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <label htmlFor="address_city" className={labelClasses}>
+                    City
+                  </label>
+                  <input
+                    id="address_city"
+                    name="address_city"
+                    value={address_city}
+                    onChange={(e) => setAddressCity(e.target.value)}
+                    required={!user}
+                    className={inputClasses}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="address_state" className={labelClasses}>
+                    State / Region
+                  </label>
+                  <input
+                    id="address_state"
+                    name="address_state"
+                    value={address_state}
+                    onChange={(e) => setAddressState(e.target.value)}
+                    className={inputClasses}
+                  />
+                </div>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <label htmlFor="address_postalCode" className={labelClasses}>
+                    Postal code
+                  </label>
+                  <input
+                    id="address_postalCode"
+                    name="address_postalCode"
+                    value={address_postalCode}
+                    onChange={(e) => setAddressPostalCode(e.target.value)}
+                    required={!user}
+                    className={inputClasses}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="address_country" className={labelClasses}>
+                    Country
+                  </label>
+                  <input
+                    id="address_country"
+                    name="address_country"
+                    value={address_country}
+                    onChange={(e) => setAddressCountry(e.target.value)}
+                    required={!user}
+                    className={inputClasses}
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-        ) : (
-          <p className="text-xs text-gray-500">You can pay in cash when the delivery arrives.</p>
-        )}
-      </div>
-      <Separator />
 
-      <div className="space-y-3">
-        <h3 className="text-lg font-semibold">Order total</h3>
-        <div className="space-y-1 text-sm">
-          <div className="flex items-center justify-between">
-            <span>Subtotal</span>
-            <span>{formatCurrency(subtotal)}</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span>Delivery ({deliveryZone === 'outside_dhaka' ? 'Outside Dhaka' : 'Inside Dhaka'})</span>
-            <span>{freeDelivery ? 'Free' : formatCurrency(shippingCharge)}</span>
-          </div>
-        </div>
-        <div className="flex items-center justify-between text-base font-semibold">
-          <span>Total</span>
-          <span>{formatCurrency(total)}</span>
-        </div>
-        {freeDelivery ? (
-          <p className="text-xs text-green-600 font-semibold">Free delivery applied for this order.</p>
-        ) : (
-          <p className="text-xs text-gray-500">
-            Spend {formatCurrency(settings.freeDeliveryThreshold)} to unlock free delivery.
-          </p>
-        )}
-      </div>
-      {error && (
-        <Alert variant="destructive">
-          <AlertDescription>{error}</AlertDescription>
-        </Alert>
-      )}
+            <div className="space-y-3">
+              <p className="text-sm font-semibold text-stone-700">Delivery area</p>
+              <p className="text-sm text-stone-500">
+                Choose whether this address is inside or outside Dhaka to calculate delivery charges accurately.
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label
+                  className={cn(
+                    'flex cursor-pointer items-start gap-3 rounded-2xl border bg-white/85 px-4 py-3 shadow-sm transition focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-2',
+                    deliveryZone === 'inside_dhaka' ? 'border-amber-400 ring-2 ring-amber-200/70' : 'border-stone-200',
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="deliveryZone"
+                    value="inside_dhaka"
+                    checked={deliveryZone === 'inside_dhaka'}
+                    onChange={() => setDeliveryZone('inside_dhaka')}
+                    className="sr-only"
+                  />
+                  <span className="mt-1 flex size-9 items-center justify-center rounded-2xl bg-amber-50 text-amber-600">
+                    <Truck className="h-5 w-5" aria-hidden />
+                  </span>
+                  <span className="space-y-1">
+                    <span className="block text-sm font-semibold text-stone-900">Inside Dhaka</span>
+                    <span className="block text-xs text-stone-500">
+                      Delivery charge {formatCurrency(settings.insideDhakaCharge)}
+                    </span>
+                  </span>
+                </label>
+                <label
+                  className={cn(
+                    'flex cursor-pointer items-start gap-3 rounded-2xl border bg-white/85 px-4 py-3 shadow-sm transition focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-2',
+                    deliveryZone === 'outside_dhaka' ? 'border-amber-400 ring-2 ring-amber-200/70' : 'border-stone-200',
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="deliveryZone"
+                    value="outside_dhaka"
+                    checked={deliveryZone === 'outside_dhaka'}
+                    onChange={() => setDeliveryZone('outside_dhaka')}
+                    className="sr-only"
+                  />
+                  <span className="mt-1 flex size-9 items-center justify-center rounded-2xl bg-amber-50 text-amber-600">
+                    <Truck className="h-5 w-5" aria-hidden />
+                  </span>
+                  <span className="space-y-1">
+                    <span className="block text-sm font-semibold text-stone-900">Outside Dhaka</span>
+                    <span className="block text-xs text-stone-500">
+                      Delivery charge {formatCurrency(settings.outsideDhakaCharge)}
+                    </span>
+                  </span>
+                </label>
+              </div>
+              {freeDelivery ? (
+                <p className="text-xs font-semibold text-emerald-600">Free delivery applied for this order.</p>
+              ) : (
+                <p className="text-xs text-stone-500">
+                  Free delivery applies automatically when your subtotal reaches {formatCurrency(settings.freeDeliveryThreshold)}.
+                </p>
+              )}
+            </div>
+          </SectionCard>
 
-      <Button type="submit" disabled={isSubmitting} className="w-full">
-        {isSubmitting ? 'Placing Order...' : 'Place Order'}
-      </Button>
-    </form>
+          <SectionCard
+            title="Payment method"
+            description="Choose how you’d like to pay for this order. Digital wallet payments require a completed transfer."
+          >
+            <div className="rounded-2xl border border-amber-100 bg-gradient-to-r from-amber-50 to-rose-50 px-4 py-3 text-sm text-amber-700">
+              Digital wallet payments have a flat delivery charge of {formatCurrency(settings.digitalPaymentDeliveryCharge)} when the
+              subtotal is below {formatCurrency(settings.freeDeliveryThreshold)}.
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {PAYMENT_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  className={cn(
+                    'flex cursor-pointer flex-col items-center gap-3 rounded-2xl border border-stone-200 bg-white/85 p-4 text-center shadow-sm transition focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-2',
+                    paymentMethod === option.value ? 'border-amber-400 ring-2 ring-amber-200/70' : '',
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="paymentMethod"
+                    value={option.value}
+                    checked={paymentMethod === option.value}
+                    onChange={() => {
+                      setPaymentMethod(option.value)
+                      if (option.value === 'cod') {
+                        setPaymentSenderNumber('')
+                        setPaymentTransactionId('')
+                      }
+                      setError('')
+                    }}
+                    className="sr-only"
+                  />
+                  <div className="relative h-12 w-24">
+                    <Image
+                      src={option.logo.src}
+                      alt={option.logo.alt}
+                      fill
+                      className="object-contain"
+                      sizes="96px"
+                      priority={option.value === 'cod'}
+                    />
+                  </div>
+                  <span className="text-sm font-semibold text-stone-800">{option.label}</span>
+                </label>
+              ))}
+            </div>
+
+            {requiresDigitalPaymentDetails ? (
+              <div className="space-y-5">
+                {digitalPaymentInstructions?.length ? (
+                  <Alert className="border-amber-100 bg-amber-50 text-amber-900">
+                    <AlertDescription>
+                      <ul className="list-disc space-y-1 pl-5 text-sm">
+                        {digitalPaymentInstructions.map((instruction, index) => (
+                          <li key={index}>{instruction}</li>
+                        ))}
+                        <li>
+                          Delivery charge is {formatCurrency(settings.digitalPaymentDeliveryCharge)} for digital wallet payments when the
+                          subtotal is below {formatCurrency(settings.freeDeliveryThreshold)}.
+                        </li>
+                      </ul>
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <label htmlFor="paymentSenderNumber" className={labelClasses}>
+                      Sender wallet number
+                    </label>
+                    <input
+                      id="paymentSenderNumber"
+                      name="paymentSenderNumber"
+                      type="tel"
+                      value={paymentSenderNumber}
+                      onChange={(e) => {
+                        setPaymentSenderNumber(e.target.value)
+                        setError('')
+                      }}
+                      required={requiresDigitalPaymentDetails}
+                      placeholder="e.g. 01XXXXXXXXX"
+                      className={inputClasses}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="paymentTransactionId" className={labelClasses}>
+                      Transaction ID
+                    </label>
+                    <input
+                      id="paymentTransactionId"
+                      name="paymentTransactionId"
+                      value={paymentTransactionId}
+                      onChange={(e) => {
+                        setPaymentTransactionId(e.target.value)
+                        setError('')
+                      }}
+                      required={requiresDigitalPaymentDetails}
+                      placeholder="e.g. TXN123456789"
+                      className={inputClasses}
+                    />
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p className="text-xs text-stone-500">You can pay in cash when the delivery arrives.</p>
+            )}
+          </SectionCard>
+
+          <SummaryPanel layout="mobile" />
+
+          <div className="flex items-start gap-3 rounded-3xl border border-amber-100 bg-white/90 px-4 py-3 text-sm text-stone-600">
+            <ShieldCheck className="mt-0.5 h-5 w-5 text-amber-500" aria-hidden />
+            <p>
+              Your information is protected with secure checkout. We’ll only use it to complete your order and coordinate the
+              delivery.
+            </p>
+          </div>
+
+          {error ? (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            className="h-12 w-full rounded-full bg-[linear-gradient(135deg,#F97316_0%,#F43F5E_100%)] px-6 text-sm font-semibold text-white shadow-lg shadow-orange-500/25 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-80"
+          >
+            {isSubmitting ? 'Placing Order…' : 'Place order securely'}
+          </Button>
+        </form>
+      </div>
+
+      <div className="space-y-6 self-start">
+        <div className="space-y-6 lg:sticky lg:top-32">
+          <ProductOverviewCard />
+          <NeedHelpCard />
+        </div>
+        <SummaryPanel layout="desktop" />
+      </div>
+    </div>
   )
 }

--- a/src/app/(frontend)/order/[id]/page.tsx
+++ b/src/app/(frontend)/order/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { headers as getHeaders } from 'next/headers.js'
-import Image from 'next/image'
 import { getPayload } from 'payload'
 import React from 'react'
 import Link from 'next/link'
@@ -11,7 +10,7 @@ import OrderForm from './order-form'
 import { normalizeDeliverySettings, DEFAULT_DELIVERY_SETTINGS } from '@/lib/delivery-settings'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
+import { Check } from 'lucide-react'
 
 export const dynamic = 'force-dynamic'
 
@@ -43,18 +42,27 @@ export default async function OrderPage({ params }: OrderPageProps) {
     .catch(() => null)
   const deliverySettings = normalizeDeliverySettings((deliverySettingsResult as any)?.docs?.[0] || DEFAULT_DELIVERY_SETTINGS)
 
+  const steps = [
+    { label: 'Product', status: 'done' as const },
+    { label: 'Checkout', status: 'current' as const },
+  ]
+
   if (!item || !item.available) {
     return (
-      <div className="min-h-screen bg-gray-50">
-        <div className="container mx-auto px-4 py-8">
-          <Card>
-            <CardHeader>
-              <CardTitle>Item Not Available</CardTitle>
-              <CardDescription>Sorry, this item is not available for ordering.</CardDescription>
+      <div className="relative min-h-screen bg-gradient-to-br from-gray-50 via-white to-stone-100">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(80%_80%_at_50%_0%,rgba(251,191,36,0.14),transparent)]" />
+        <SiteHeader variant="full" user={(fullUser as any) || (user as any)} />
+        <div className="relative mx-auto w-full max-w-4xl px-4 pb-16 pt-20 sm:pt-24">
+          <Card className="rounded-3xl border border-amber-100/80 bg-white/90 shadow-xl shadow-amber-200/60 backdrop-blur">
+            <CardHeader className="space-y-2 text-center">
+              <CardTitle className="text-2xl font-semibold text-stone-900">Item not available</CardTitle>
+              <CardDescription className="text-base text-stone-500">
+                Sorry, this item is not available for ordering right now. Please explore other products.
+              </CardDescription>
             </CardHeader>
-            <CardContent>
-              <Button asChild>
-                <Link href="/">Back to Home</Link>
+            <CardContent className="flex justify-center pb-8">
+              <Button asChild className="rounded-full bg-gradient-to-r from-amber-500 to-rose-500 px-6 font-semibold text-white shadow-lg shadow-amber-500/25 transition hover:from-amber-600 hover:to-rose-600">
+                <Link href="/">Back to shopping</Link>
               </Button>
             </CardContent>
           </Card>
@@ -64,61 +72,50 @@ export default async function OrderPage({ params }: OrderPageProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="relative min-h-screen bg-gradient-to-br from-gray-50 via-white to-stone-100">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(80%_80%_at_50%_0%,rgba(251,191,36,0.14),transparent)]" />
       <SiteHeader variant="full" user={(fullUser as any) || (user as any)} />
-      <div className="container mx-auto px-4 py-8">
-        <Button asChild variant="ghost" className="mb-6">
-          <Link href="/">← Back to Items</Link>
-        </Button>
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          {/* Item Details */}
-          <Card className="overflow-hidden">
-            {item.image && typeof item.image === 'object' && item.image.url && (
-              <div className="aspect-video relative">
-                <Image
-                  src={item.image.url}
-                  alt={item.image.alt || item.name}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            )}
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-2xl">{item.name}</CardTitle>
-                <Badge variant="secondary">{typeof (item as any).category === 'object' ? ((item as any).category as any)?.name : (item as any).category}</Badge>
-              </div>
-              <CardDescription className="whitespace-pre-line">
-                {item.shortDescription ?? item.description}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <p className="text-2xl font-bold text-green-600">৳{item.price.toFixed(2)} each</p>
-            </CardContent>
-          </Card>
-
-          {/* Order Form */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Place Your Order</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {!user ? (
-                <div className="mb-4 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
-                  <p className="font-medium">Guest checkout</p>
-                  <p className="mt-1">
-                    You can order this item without an account. We’ll ask for your contact and shipping details.
-                    Want to save your details?{' '}
-                    <Link className="underline font-medium" href="/register">Create an account</Link>{' '}
-                    or <Link className="underline font-medium" href="/login">sign in</Link>.
-                  </p>
-                </div>
-              ) : null}
-              <OrderForm item={item} user={(fullUser as any) || (user as any)} deliverySettings={deliverySettings} />
-            </CardContent>
-          </Card>
+      <div className="relative mx-auto w-full max-w-6xl px-4 pb-16 pt-10 lg:px-8 lg:pt-16">
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          <Button
+            asChild
+            variant="ghost"
+            className="h-11 rounded-full border border-transparent bg-white/80 px-4 text-sm font-semibold text-stone-600 shadow-sm backdrop-blur transition hover:border-amber-200 hover:bg-white hover:text-amber-600"
+          >
+            <Link href="/">← Back to shopping</Link>
+          </Button>
+          <div className="flex flex-wrap items-center gap-3 text-sm font-medium text-stone-500">
+            {steps.map((step, index) => (
+              <React.Fragment key={step.label}>
+                <span
+                  className={
+                    step.status === 'current'
+                      ? 'flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-amber-600'
+                      : 'flex items-center gap-2 text-stone-500'
+                  }
+                >
+                  <span
+                    className={
+                      step.status === 'done'
+                        ? 'flex size-6 items-center justify-center rounded-full bg-gradient-to-r from-amber-500 to-rose-500 text-xs font-semibold text-white shadow'
+                        : 'flex size-6 items-center justify-center rounded-full border border-amber-200 bg-white text-xs font-semibold text-amber-600 shadow-sm'
+                    }
+                    aria-hidden
+                  >
+                    {step.status === 'done' ? <Check className="h-3 w-3" /> : index + 1}
+                  </span>
+                  {step.label}
+                </span>
+                {index < steps.length - 1 ? <span className="hidden h-px w-8 bg-stone-300 sm:block" aria-hidden /> : null}
+              </React.Fragment>
+            ))}
+          </div>
         </div>
+        <OrderForm
+          item={item}
+          user={(fullUser as any) || (user as any)}
+          deliverySettings={deliverySettings}
+        />
       </div>
     </div>
   )

--- a/src/components/cart-sidebar.tsx
+++ b/src/components/cart-sidebar.tsx
@@ -174,7 +174,7 @@ export const CartSidebar: React.FC = () => {
               <div className="space-y-3">
                 <Button
                   asChild
-                  className="w-full bg-gradient-to-r from-amber-500 to-rose-500 hover:from-amber-600 hover:to-rose-600 border-0 text-white py-3 rounded-full shadow-lg hover:shadow-amber-500/25 transition-all duration-300 hover:scale-105"
+                  className="w-full rounded-full border-0 bg-[linear-gradient(135deg,#F97316_0%,#F43F5E_100%)] py-3 text-white shadow-lg shadow-orange-500/25 transition-all duration-300 hover:scale-105 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2"
                   size="lg"
                 >
                   <Link href="/checkout" onClick={closeCart}>


### PR DESCRIPTION
## Summary
- retheme the checkout and single-item order shells to use the site's warm gradient background and updated step indicator styling
- refresh the order sidebar with a sticky product overview plus contact-ready "Need help?" card and apply the new gradient CTA styling to the order submit button
- match checkout and cart CTAs to the updated proceed/pay gradient for a consistent call-to-action treatment across flows

## Testing
- pnpm lint *(passes with existing warnings about legacy `any` usage and unused variables)*

------
https://chatgpt.com/codex/tasks/task_b_68cbc46e5c08832a9288722e9b1d18f2