### PR TITLE
Reposition payment options on checkout and order pages

### DIFF
--- a/src/app/(frontend)/checkout/checkout-form.tsx
+++ b/src/app/(frontend)/checkout/checkout-form.tsx
@@ -88,133 +88,249 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
       <div className="mt-5 space-y-5">{children}</div>
     </div>
   )
-  const OrderSummaryCard = ({ className, layout }: { className?: string; layout: 'desktop' | 'mobile' }) => (
-    <div
-      className={cn(
-        'w-full rounded-[26px] border border-amber-100/80 bg-white/90 p-6 shadow-xl shadow-amber-200/60 backdrop-blur-sm',
-        layout === 'desktop' ? 'lg:sticky lg:top-28' : '',
-        className,
-      )}
-    >
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h3 className="text-lg font-semibold text-stone-900">Review your cart</h3>
-          <p className="text-sm text-stone-500">Double-check the details before you place your order.</p>
-        </div>
-        <Badge className="ml-auto h-7 rounded-full bg-amber-100 px-3 text-xs font-medium text-amber-700">
-          Secure checkout
-        </Badge>
-      </div>
-      <div className="mt-5 space-y-4">
-        {state.items.map((item) => (
-          <div
-            key={item.id}
-            className="flex items-start gap-4 rounded-2xl border border-amber-50 bg-white/85 p-4 shadow-sm shadow-amber-200/40"
-          >
-            {item.image ? (
-              <div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-xl border border-amber-100 bg-amber-50">
-                <Image
-                  src={item.image.url}
-                  alt={item.image.alt || item.name}
-                  fill
-                  sizes="64px"
-                  className="object-cover"
-                />
-              </div>
-            ) : null}
-            <div className="min-w-0 flex-1 space-y-1">
-              <div className="flex items-center gap-2">
-                <h4 className="truncate text-sm font-semibold text-stone-900">{item.name}</h4>
-                {item.category ? (
-                  <Badge className="hidden rounded-full bg-stone-100 px-2.5 py-0.5 text-[11px] font-medium text-stone-600 sm:inline-flex">
-                    {item.category}
-                  </Badge>
-                ) : null}
-              </div>
-              <p className="text-xs text-stone-500">{formatCurrency(item.price)} each</p>
-            </div>
-            <div className="flex flex-col items-end gap-3 text-right">
-              <div className="flex items-center gap-2 rounded-full border border-stone-200 bg-white/80 px-2 py-1 shadow-sm">
-                <button
-                  type="button"
-                  onClick={() => updateQuantity(item.id, Math.max(1, item.quantity - 1))}
-                  disabled={item.quantity <= 1}
-                  aria-label={`Decrease quantity of ${item.name}`}
-                  className="flex h-7 w-7 items-center justify-center rounded-full text-stone-500 transition hover:bg-amber-50 hover:text-amber-600 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white"
-                >
-                  <Minus className="h-4 w-4" />
-                </button>
-                <span className="min-w-[2ch] text-sm font-semibold text-stone-900">{item.quantity}</span>
-                <button
-                  type="button"
-                  onClick={() => updateQuantity(item.id, item.quantity + 1)}
-                  aria-label={`Increase quantity of ${item.name}`}
-                  className="flex h-7 w-7 items-center justify-center rounded-full text-stone-500 transition hover:bg-amber-50 hover:text-amber-600"
-                >
-                  <Plus className="h-4 w-4" />
-                </button>
-              </div>
-              <p className="text-sm font-semibold text-stone-900">{formatCurrency(item.price * item.quantity)}</p>
-            </div>
+  const OrderSummaryCard = ({ className, layout }: { className?: string; layout: 'desktop' | 'mobile' }) => {
+    const senderNumberId = `paymentSenderNumber-${layout}`
+    const transactionId = `paymentTransactionId-${layout}`
+
+    return (
+      <div
+        className={cn(
+          'w-full rounded-[26px] border border-amber-100/80 bg-white/90 p-6 shadow-xl shadow-amber-200/60 backdrop-blur-sm',
+          layout === 'desktop' ? 'lg:sticky lg:top-28' : '',
+          className,
+        )}
+      >
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-stone-900">Review your cart</h3>
+            <p className="text-sm text-stone-500">Double-check the details before you place your order.</p>
           </div>
-        ))}
-      </div>
-      <div className="mt-6 space-y-3">
-        <label htmlFor={`discount-${layout}`} className="text-sm font-semibold text-stone-700">
-          Discount code
-        </label>
-        <div className="flex flex-col gap-3 sm:flex-row">
-          <input
-            id={`discount-${layout}`}
-            type="text"
-            value={discountCode}
-            onChange={(e) => setDiscountCode(e.target.value)}
-            placeholder="Enter promo code"
-            className="flex-1 rounded-xl border border-stone-200 bg-white px-4 py-2 text-sm text-stone-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400/70"
-          />
+          <Badge className="ml-auto h-7 rounded-full bg-amber-100 px-3 text-xs font-medium text-amber-700">
+            Secure checkout
+          </Badge>
+        </div>
+        <div className="mt-5 space-y-4">
+          {state.items.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-start gap-4 rounded-2xl border border-amber-50 bg-white/85 p-4 shadow-sm shadow-amber-200/40"
+            >
+              {item.image ? (
+                <div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-xl border border-amber-100 bg-amber-50">
+                  <Image
+                    src={item.image.url}
+                    alt={item.image.alt || item.name}
+                    fill
+                    sizes="64px"
+                    className="object-cover"
+                  />
+                </div>
+              ) : null}
+              <div className="min-w-0 flex-1 space-y-1">
+                <div className="flex items-center gap-2">
+                  <h4 className="truncate text-sm font-semibold text-stone-900">{item.name}</h4>
+                  {item.category ? (
+                    <Badge className="hidden rounded-full bg-stone-100 px-2.5 py-0.5 text-[11px] font-medium text-stone-600 sm:inline-flex">
+                      {item.category}
+                    </Badge>
+                  ) : null}
+                </div>
+                <p className="text-xs text-stone-500">{formatCurrency(item.price)} each</p>
+              </div>
+              <div className="flex flex-col items-end gap-3 text-right">
+                <div className="flex items-center gap-2 rounded-full border border-stone-200 bg-white/80 px-2 py-1 shadow-sm">
+                  <button
+                    type="button"
+                    onClick={() => updateQuantity(item.id, Math.max(1, item.quantity - 1))}
+                    disabled={item.quantity <= 1}
+                    aria-label={`Decrease quantity of ${item.name}`}
+                    className="flex h-7 w-7 items-center justify-center rounded-full text-stone-500 transition hover:bg-amber-50 hover:text-amber-600 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white"
+                  >
+                    <Minus className="h-4 w-4" />
+                  </button>
+                  <span className="min-w-[2ch] text-sm font-semibold text-stone-900">{item.quantity}</span>
+                  <button
+                    type="button"
+                    onClick={() => updateQuantity(item.id, item.quantity + 1)}
+                    aria-label={`Increase quantity of ${item.name}`}
+                    className="flex h-7 w-7 items-center justify-center rounded-full text-stone-500 transition hover:bg-amber-50 hover:text-amber-600"
+                  >
+                    <Plus className="h-4 w-4" />
+                  </button>
+                </div>
+                <p className="text-sm font-semibold text-stone-900">{formatCurrency(item.price * item.quantity)}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-6 space-y-3">
+          <label htmlFor={`discount-${layout}`} className="text-sm font-semibold text-stone-700">
+            Discount code
+          </label>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <input
+              id={`discount-${layout}`}
+              type="text"
+              value={discountCode}
+              onChange={(e) => setDiscountCode(e.target.value)}
+              placeholder="Enter promo code"
+              className="flex-1 rounded-xl border border-stone-200 bg-white px-4 py-2 text-sm text-stone-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400/70"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-xl border-amber-200 bg-amber-50 text-amber-700 shadow-sm transition hover:bg-amber-100"
+            >
+              Apply
+            </Button>
+          </div>
+          <p className="text-xs text-stone-500">Promotions are applied before taxes and shipping charges.</p>
+        </div>
+        <Separator className="my-6" />
+        <div className="space-y-3 text-sm text-stone-600">
+          <div className="flex items-center justify-between">
+            <span>Subtotal</span>
+            <span className="font-medium text-stone-900">{formatCurrency(subtotal)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>
+              Shipping {deliveryZone === 'outside_dhaka' ? '(Outside Dhaka)' : '(Inside Dhaka)'}
+            </span>
+            <span className="font-medium text-stone-900">{freeDelivery ? 'Free' : formatCurrency(shippingCharge)}</span>
+          </div>
+          <div className="flex items-center justify-between text-base font-semibold text-stone-900">
+            <span>Total</span>
+            <span>{formatCurrency(total)}</span>
+          </div>
+        </div>
+        <Separator className="my-6" />
+        <div className="space-y-5">
+          <div className="space-y-2">
+            <div>
+              <h4 className="text-base font-semibold text-stone-900">Payment method</h4>
+              <p className="text-xs text-stone-500">Choose how you would like to pay for this order.</p>
+            </div>
+            <div className="rounded-2xl border border-amber-200/70 bg-amber-50/80 p-4 text-xs font-medium text-amber-900 shadow-sm shadow-amber-100">
+              Digital wallet payments have a flat delivery charge of{' '}
+              <span className="font-semibold">{formatCurrency(settings.digitalPaymentDeliveryCharge)}</span> when the subtotal is below{' '}
+              <span className="font-semibold">{formatCurrency(settings.freeDeliveryThreshold)}</span>.
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              {PAYMENT_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  className={cn(
+                    'group flex cursor-pointer flex-col items-center gap-3 rounded-2xl border border-stone-200 bg-white/85 p-4 text-center shadow-sm transition hover:border-amber-200 hover:shadow-amber-100 focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-0',
+                    paymentMethod === option.value ? 'border-amber-400 shadow-amber-100 ring-2 ring-amber-200/80' : '',
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="paymentMethod"
+                    value={option.value}
+                    checked={paymentMethod === option.value}
+                    onChange={() => {
+                      setPaymentMethod(option.value)
+                      if (option.value === 'cod') {
+                        setPaymentSenderNumber('')
+                        setPaymentTransactionId('')
+                      }
+                      setError(null)
+                    }}
+                    className="sr-only"
+                    form={formId}
+                  />
+                  <div className="relative h-16 w-32">
+                    <Image
+                      src={option.logo.src}
+                      alt={option.logo.alt}
+                      width={option.logo.width}
+                      height={option.logo.height}
+                      className="h-full w-full object-contain"
+                      sizes="128px"
+                      priority={option.value === 'cod'}
+                    />
+                  </div>
+                  <span className="text-sm font-medium text-stone-700">{option.label}</span>
+                </label>
+              ))}
+            </div>
+            {requiresDigitalPaymentDetails ? (
+              <div className="space-y-5 rounded-2xl border border-amber-100 bg-amber-50/70 p-5 text-amber-900 shadow-sm shadow-amber-100">
+                {digitalPaymentInstructions?.length ? (
+                  <Alert className="border-transparent bg-transparent p-0 text-amber-900">
+                    <AlertDescription>
+                      <ul className="list-disc space-y-1 pl-5 text-sm">
+                        {digitalPaymentInstructions.map((instruction, index) => (
+                          <li key={`${layout}-instruction-${index}`}>{instruction}</li>
+                        ))}
+                      </ul>
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <label htmlFor={senderNumberId} className="text-sm font-medium text-stone-600">
+                      Sender wallet number
+                    </label>
+                    <input
+                      id={senderNumberId}
+                      name="paymentSenderNumber"
+                      type="tel"
+                      value={paymentSenderNumber}
+                      onChange={(e) => {
+                        setPaymentSenderNumber(e.target.value)
+                        setError(null)
+                      }}
+                      required={requiresDigitalPaymentDetails}
+                      placeholder="e.g. 01XXXXXXXXX"
+                      className={inputClasses}
+                      form={formId}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor={transactionId} className="text-sm font-medium text-stone-600">
+                      Transaction ID
+                    </label>
+                    <input
+                      id={transactionId}
+                      name="paymentTransactionId"
+                      type="text"
+                      value={paymentTransactionId}
+                      onChange={(e) => {
+                        setPaymentTransactionId(e.target.value)
+                        setError(null)
+                      }}
+                      required={requiresDigitalPaymentDetails}
+                      placeholder="e.g. TXN123456789"
+                      className={inputClasses}
+                      form={formId}
+                    />
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p className="text-xs text-stone-500">Pay with cash when your delivery arrives.</p>
+            )}
+          </div>
+        </div>
+        <div className="space-y-3">
           <Button
-            type="button"
-            variant="outline"
-            className="rounded-xl border-amber-200 bg-amber-50 text-amber-700 shadow-sm transition hover:bg-amber-100"
+            type="submit"
+            form={formId}
+            size="lg"
+            className="w-full rounded-full bg-[linear-gradient(135deg,#F97316_0%,#F43F5E_100%)] text-white shadow-lg shadow-orange-500/25 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2"
           >
-            Apply
+            {isSubmitting ? 'Processing…' : 'Confirm order'}
           </Button>
-        </div>
-        <p className="text-xs text-stone-500">Promotions are applied before taxes and shipping charges.</p>
-      </div>
-      <Separator className="my-6" />
-      <div className="space-y-3 text-sm text-stone-600">
-        <div className="flex items-center justify-between">
-          <span>Subtotal</span>
-          <span className="font-medium text-stone-900">{formatCurrency(subtotal)}</span>
-        </div>
-        <div className="flex items-center justify-between">
-          <span>
-            Shipping {deliveryZone === 'outside_dhaka' ? '(Outside Dhaka)' : '(Inside Dhaka)'}
-          </span>
-          <span className="font-medium text-stone-900">{freeDelivery ? 'Free' : formatCurrency(shippingCharge)}</span>
-        </div>
-        <div className="flex items-center justify-between text-base font-semibold text-stone-900">
-          <span>Total</span>
-          <span>{formatCurrency(total)}</span>
+          <div className="flex items-start gap-2 text-xs text-stone-500">
+            <ShieldCheck className="mt-0.5 h-4 w-4 text-amber-500" />
+            <span>Secure checkout • Your payment details are encrypted end-to-end.</span>
+          </div>
         </div>
       </div>
-      <div className="mt-6 space-y-3">
-        <Button
-          type="submit"
-          form={formId}
-          size="lg"
-          className="w-full rounded-full bg-[linear-gradient(135deg,#F97316_0%,#F43F5E_100%)] text-white shadow-lg shadow-orange-500/25 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2"
-        >
-          {isSubmitting ? 'Processing…' : 'Pay now'}
-        </Button>
-        <div className="flex items-start gap-2 text-xs text-stone-500">
-          <ShieldCheck className="mt-0.5 h-4 w-4 text-amber-500" />
-          <span>Secure checkout • Your payment details are encrypted end-to-end.</span>
-        </div>
-      </div>
-    </div>
-  )
+    )
+  }
 
   React.useEffect(() => {
     if (deliveryZone === 'inside_dhaka') {
@@ -691,114 +807,6 @@ export const CheckoutForm: React.FC<CheckoutFormProps> = ({ user, deliverySettin
           </Alert>
         ) : null}
         </form>
-        <SectionCard
-          title="Payment method"
-          description="Choose how you would like to pay for this order."
-          className="rounded-[26px] border-amber-100/80 bg-white/90 shadow-xl shadow-amber-200/60 backdrop-blur-sm"
-        >
-          <div className="rounded-2xl border border-amber-200/70 bg-amber-50/80 p-4 text-sm font-medium text-amber-900 shadow-sm shadow-amber-100">
-            Digital wallet payments have a flat delivery charge of{' '}
-            <span className="font-semibold">{formatCurrency(settings.digitalPaymentDeliveryCharge)}</span> when the subtotal is
-            below <span className="font-semibold">{formatCurrency(settings.freeDeliveryThreshold)}</span>.
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-            {PAYMENT_OPTIONS.map((option) => (
-              <label
-                key={option.value}
-                className={cn(
-                  'group flex cursor-pointer flex-col items-center gap-3 rounded-2xl border border-stone-200 bg-white/85 p-4 text-center shadow-sm transition hover:border-amber-200 hover:shadow-amber-100 focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-0',
-                  paymentMethod === option.value ? 'border-amber-400 shadow-amber-100 ring-2 ring-amber-200/80' : '',
-                )}
-              >
-                <input
-                  type="radio"
-                  name="paymentMethod"
-                  value={option.value}
-                  checked={paymentMethod === option.value}
-                  onChange={() => {
-                    setPaymentMethod(option.value)
-                    if (option.value === 'cod') {
-                      setPaymentSenderNumber('')
-                      setPaymentTransactionId('')
-                    }
-                    setError(null)
-                  }}
-                  className="sr-only"
-                  form={formId}
-                />
-                <div className="relative h-16 w-32">
-                  <Image
-                    src={option.logo.src}
-                    alt={option.logo.alt}
-                    width={option.logo.width}
-                    height={option.logo.height}
-                    className="h-full w-full object-contain"
-                    sizes="128px"
-                    priority={option.value === 'cod'}
-                  />
-                </div>
-                <span className="text-sm font-medium text-stone-700">{option.label}</span>
-              </label>
-            ))}
-          </div>
-          {requiresDigitalPaymentDetails ? (
-            <div className="space-y-5 rounded-2xl border border-amber-100 bg-amber-50/70 p-5 text-amber-900 shadow-sm shadow-amber-100">
-              {digitalPaymentInstructions?.length ? (
-                <Alert className="border-transparent bg-transparent p-0 text-amber-900">
-                  <AlertDescription>
-                    <ul className="list-disc space-y-1 pl-5 text-sm">
-                      {digitalPaymentInstructions.map((instruction, index) => (
-                        <li key={index}>{instruction}</li>
-                      ))}
-                    </ul>
-                  </AlertDescription>
-                </Alert>
-              ) : null}
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <label htmlFor="paymentSenderNumber" className="text-sm font-medium text-stone-600">
-                    Sender wallet number
-                  </label>
-                  <input
-                    id="paymentSenderNumber"
-                    name="paymentSenderNumber"
-                    type="tel"
-                    value={paymentSenderNumber}
-                    onChange={(e) => {
-                      setPaymentSenderNumber(e.target.value)
-                      setError(null)
-                    }}
-                    required={requiresDigitalPaymentDetails}
-                    placeholder="e.g. 01XXXXXXXXX"
-                    className={inputClasses}
-                    form={formId}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label htmlFor="paymentTransactionId" className="text-sm font-medium text-stone-600">
-                    Transaction ID
-                  </label>
-                  <input
-                    id="paymentTransactionId"
-                    name="paymentTransactionId"
-                    type="text"
-                    value={paymentTransactionId}
-                    onChange={(e) => {
-                      setPaymentTransactionId(e.target.value)
-                      setError(null)
-                    }}
-                    required={requiresDigitalPaymentDetails}
-                    placeholder="e.g. TXN123456789"
-                    className={inputClasses}
-                    form={formId}
-                  />
-                </div>
-              </div>
-            </div>
-          ) : (
-            <p className="text-xs text-stone-500">Pay with cash when your delivery arrives.</p>
-          )}
-        </SectionCard>
         <OrderSummaryCard className="lg:hidden" layout="mobile" />
       </div>
       <div className="min-w-0 space-y-6">

--- a/src/app/(frontend)/order/[id]/order-form.tsx
+++ b/src/app/(frontend)/order/[id]/order-form.tsx
@@ -8,6 +8,7 @@ import { Minus, Plus, ShieldCheck, Truck } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
 import type { DeliverySettings } from '@/lib/delivery-settings'
 import { DEFAULT_DELIVERY_SETTINGS } from '@/lib/delivery-settings'
 import { cn } from '@/lib/utils'
@@ -128,6 +129,8 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
 
   const SummaryPanel = ({ layout }: { layout: 'mobile' | 'desktop' }) => {
     const isDesktop = layout === 'desktop'
+    const senderNumberId = `order-paymentSenderNumber-${layout}`
+    const transactionId = `order-paymentTransactionId-${layout}`
 
     return (
       <div
@@ -138,8 +141,8 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
       >
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h3 className="text-lg font-semibold text-stone-900">Review your cart</h3>
-            <p className="text-sm text-stone-500">Confirm the quantity and totals before placing your order.</p>
+            <h3 className="text-lg font-semibold text-stone-900">Review your order</h3>
+            <p className="text-sm text-stone-500">Confirm the quantity, payment method, and totals before placing your order.</p>
           </div>
           <div className="flex flex-col items-end gap-2 text-right">
             <Badge className="h-7 rounded-full bg-amber-100 px-3 text-xs font-medium text-amber-700">Secure checkout</Badge>
@@ -195,6 +198,117 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
           )}
         </div>
 
+        <Separator className="my-6" />
+
+        <div className="space-y-5">
+          <div>
+            <h4 className="text-base font-semibold text-stone-900">Payment method</h4>
+            <p className="text-xs text-stone-500">Select a payment option to complete your order.</p>
+          </div>
+          <div className="rounded-2xl border border-amber-200/70 bg-amber-50/80 p-4 text-xs font-medium text-amber-900 shadow-sm shadow-amber-100">
+            Digital wallet payments have a flat delivery charge of {formatCurrency(settings.digitalPaymentDeliveryCharge)} when the subtotal is below {formatCurrency(settings.freeDeliveryThreshold)}.
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {PAYMENT_OPTIONS.map((option) => (
+              <label
+                key={option.value}
+                className={cn(
+                  'group flex cursor-pointer flex-col items-center gap-3 rounded-2xl border border-stone-200 bg-white/85 p-4 text-center shadow-sm transition hover:border-amber-200 hover:shadow-amber-100 focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-0',
+                  paymentMethod === option.value ? 'border-amber-400 shadow-amber-100 ring-2 ring-amber-200/80' : '',
+                )}
+              >
+                <input
+                  type="radio"
+                  name="paymentMethod"
+                  value={option.value}
+                  checked={paymentMethod === option.value}
+                  onChange={() => {
+                    setPaymentMethod(option.value)
+                    if (option.value === 'cod') {
+                      setPaymentSenderNumber('')
+                      setPaymentTransactionId('')
+                    }
+                    setError('')
+                  }}
+                  className="sr-only"
+                  form="order-form"
+                />
+                <div className="relative h-16 w-32">
+                  <Image
+                    src={option.logo.src}
+                    alt={option.logo.alt}
+                    width={option.logo.width}
+                    height={option.logo.height}
+                    className="h-full w-full object-contain"
+                    sizes="128px"
+                    priority={option.value === 'cod'}
+                  />
+                </div>
+                <span className="text-sm font-medium text-stone-700">{option.label}</span>
+              </label>
+            ))}
+          </div>
+          {requiresDigitalPaymentDetails ? (
+            <div className="space-y-5 rounded-2xl border border-amber-100 bg-amber-50/70 p-5 text-amber-900 shadow-sm shadow-amber-100">
+              {digitalPaymentInstructions?.length ? (
+                <Alert className="border-transparent bg-transparent p-0 text-amber-900">
+                  <AlertDescription>
+                    <ul className="list-disc space-y-1 pl-5 text-sm">
+                      {digitalPaymentInstructions.map((instruction, index) => (
+                        <li key={`${layout}-digital-instruction-${index}`}>{instruction}</li>
+                      ))}
+                      <li>
+                        Delivery charge is {formatCurrency(settings.digitalPaymentDeliveryCharge)} for digital wallet payments when the subtotal is below {formatCurrency(settings.freeDeliveryThreshold)}.
+                      </li>
+                    </ul>
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label htmlFor={senderNumberId} className="text-sm font-medium text-stone-600">
+                    Sender wallet number
+                  </label>
+                  <input
+                    id={senderNumberId}
+                    name="paymentSenderNumber"
+                    type="tel"
+                    value={paymentSenderNumber}
+                    onChange={(e) => {
+                      setPaymentSenderNumber(e.target.value)
+                      setError('')
+                    }}
+                    required={requiresDigitalPaymentDetails}
+                    placeholder="e.g. 01XXXXXXXXX"
+                    className={inputClasses}
+                    form="order-form"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor={transactionId} className="text-sm font-medium text-stone-600">
+                    Transaction ID
+                  </label>
+                  <input
+                    id={transactionId}
+                    name="paymentTransactionId"
+                    value={paymentTransactionId}
+                    onChange={(e) => {
+                      setPaymentTransactionId(e.target.value)
+                      setError('')
+                    }}
+                    required={requiresDigitalPaymentDetails}
+                    placeholder="e.g. TXN123456789"
+                    className={inputClasses}
+                    form="order-form"
+                  />
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p className="text-xs text-stone-500">You can pay in cash when the delivery arrives.</p>
+          )}
+        </div>
+
         <div className="mt-5 flex items-start gap-3 rounded-3xl border border-amber-100 bg-white/90 px-4 py-3 text-sm text-stone-600">
           <ShieldCheck className="mt-0.5 h-5 w-5 text-amber-500" aria-hidden />
           <p>Your information is protected with secure checkout. We’ll only use it to complete your order and coordinate the delivery.</p>
@@ -206,7 +320,7 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
           disabled={isSubmitting}
           className="mt-6 w-full rounded-full bg-[linear-gradient(135deg,#F97316_0%,#F43F5E_100%)] px-6 text-sm font-semibold text-white shadow-lg shadow-orange-500/25 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-80"
         >
-          {isSubmitting ? 'Placing Order…' : 'Place order securely'}
+          {isSubmitting ? 'Placing Order…' : 'Confirm order'}
         </Button>
       </div>
     )
@@ -582,113 +696,6 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
                 </p>
               )}
             </div>
-          </SectionCard>
-
-          <SectionCard
-            title="Payment method"
-            description="Choose how you’d like to pay for this order. Digital wallet payments require a completed transfer."
-          >
-            <div className="rounded-2xl border border-amber-100 bg-gradient-to-r from-amber-50 to-rose-50 px-4 py-3 text-sm text-amber-700">
-              Digital wallet payments have a flat delivery charge of {formatCurrency(settings.digitalPaymentDeliveryCharge)} when the
-              subtotal is below {formatCurrency(settings.freeDeliveryThreshold)}.
-            </div>
-            <div className="grid gap-3 sm:grid-cols-3">
-              {PAYMENT_OPTIONS.map((option) => (
-                <label
-                  key={option.value}
-                  className={cn(
-                    'flex cursor-pointer flex-col items-center gap-3 rounded-2xl border border-stone-200 bg-white/85 p-4 text-center shadow-sm transition focus-within:ring-2 focus-within:ring-amber-400/70 focus-within:ring-offset-2',
-                    paymentMethod === option.value ? 'border-amber-400 ring-2 ring-amber-200/70' : '',
-                  )}
-                >
-                  <input
-                    type="radio"
-                    name="paymentMethod"
-                    value={option.value}
-                    checked={paymentMethod === option.value}
-                    onChange={() => {
-                      setPaymentMethod(option.value)
-                      if (option.value === 'cod') {
-                        setPaymentSenderNumber('')
-                        setPaymentTransactionId('')
-                      }
-                      setError('')
-                    }}
-                    className="sr-only"
-                  />
-                  <div className="relative h-12 w-24">
-                    <Image
-                      src={option.logo.src}
-                      alt={option.logo.alt}
-                      fill
-                      className="object-contain"
-                      sizes="96px"
-                      priority={option.value === 'cod'}
-                    />
-                  </div>
-                  <span className="text-sm font-semibold text-stone-800">{option.label}</span>
-                </label>
-              ))}
-            </div>
-
-            {requiresDigitalPaymentDetails ? (
-              <div className="space-y-5">
-                {digitalPaymentInstructions?.length ? (
-                  <Alert className="border-amber-100 bg-amber-50 text-amber-900">
-                    <AlertDescription>
-                      <ul className="list-disc space-y-1 pl-5 text-sm">
-                        {digitalPaymentInstructions.map((instruction, index) => (
-                          <li key={index}>{instruction}</li>
-                        ))}
-                        <li>
-                          Delivery charge is {formatCurrency(settings.digitalPaymentDeliveryCharge)} for digital wallet payments when the
-                          subtotal is below {formatCurrency(settings.freeDeliveryThreshold)}.
-                        </li>
-                      </ul>
-                    </AlertDescription>
-                  </Alert>
-                ) : null}
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div className="space-y-2">
-                    <label htmlFor="paymentSenderNumber" className={labelClasses}>
-                      Sender wallet number
-                    </label>
-                    <input
-                      id="paymentSenderNumber"
-                      name="paymentSenderNumber"
-                      type="tel"
-                      value={paymentSenderNumber}
-                      onChange={(e) => {
-                        setPaymentSenderNumber(e.target.value)
-                        setError('')
-                      }}
-                      required={requiresDigitalPaymentDetails}
-                      placeholder="e.g. 01XXXXXXXXX"
-                      className={inputClasses}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label htmlFor="paymentTransactionId" className={labelClasses}>
-                      Transaction ID
-                    </label>
-                    <input
-                      id="paymentTransactionId"
-                      name="paymentTransactionId"
-                      value={paymentTransactionId}
-                      onChange={(e) => {
-                        setPaymentTransactionId(e.target.value)
-                        setError('')
-                      }}
-                      required={requiresDigitalPaymentDetails}
-                      placeholder="e.g. TXN123456789"
-                      className={inputClasses}
-                    />
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <p className="text-xs text-stone-500">You can pay in cash when the delivery arrives.</p>
-            )}
           </SectionCard>
 
           <SummaryPanel layout="mobile" />

--- a/src/app/(frontend)/order/[id]/order-form.tsx
+++ b/src/app/(frontend)/order/[id]/order-form.tsx
@@ -698,6 +698,8 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
             </div>
           </SectionCard>
 
+          <NeedHelpCard />
+
           <SummaryPanel layout="mobile" />
 
           {error ? (
@@ -711,7 +713,6 @@ export default function OrderForm({ item, user, deliverySettings }: OrderFormPro
       <div className="space-y-6 self-start lg:sticky lg:top-32">
         <ProductOverviewCard />
         <SummaryPanel layout="desktop" />
-        <NeedHelpCard />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- move the payment method selector into the review card on the checkout page and keep digital wallet fields there
- mirror the same review-first experience on the single item order page and rename the action button to "Confirm order"

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cc20d7ebd8832a8cdd8f42bfb69d6b